### PR TITLE
drop string extension to not pollute methods

### DIFF
--- a/lib/cvss_suite.rb
+++ b/lib/cvss_suite.rb
@@ -10,7 +10,6 @@ require 'cvss_suite/cvss40/cvss40'
 require 'cvss_suite/version'
 require 'cvss_suite/errors'
 require 'cvss_suite/invalid_cvss'
-require 'cvss_suite/extensions/string'
 
 ##
 # Module of this gem.

--- a/lib/cvss_suite/cvss40/cvss40_calc_helper.rb
+++ b/lib/cvss_suite/cvss40/cvss40_calc_helper.rb
@@ -377,13 +377,21 @@ module CvssSuite
       # remove what follow
       if extracted.index('/').positive?
         index_to_drop_after = extracted.index('/') - 1
-        metric_val = extracted.truncate(index_to_drop_after)
+        metric_val = truncate(extracted, index_to_drop_after)
       elsif extracted
         metric_val = extracted
         # case where it is the last metric so no ending /
       end
 
       metric_val
+    end
+
+    # rails defines this method on String, so we need to avoid polluting the
+    #  String class to preserve Rails behavior.
+    def truncate(string_to_truncate, truncate_to)
+      return string_to_truncate.dup unless string_to_truncate.length > truncate_to
+
+      (string_to_truncate[0, truncate_to + 1]).to_s
     end
   end
 end

--- a/lib/cvss_suite/extensions/string.rb
+++ b/lib/cvss_suite/extensions/string.rb
@@ -1,8 +1,0 @@
-# Extension for String class
-class String
-  def truncate(truncate_to)
-    return dup unless length > truncate_to
-
-    (self[0, truncate_to + 1]).to_s
-  end
-end


### PR DESCRIPTION
## Proposed changes

This is dropping the definition of truncate on String -- this seems to pollute the method in my usages, where the default [rails method](https://apidock.com/rails/String/truncate) gets replaced with a method that doesn't match the signature.

https://github.com/0llirocks/cvss-suite/issues/39

## Types of changes

What types of changes does your code introduce to CvssSuite?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [X] Unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

