### PR TITLE
Update strings for frozen string compatibility

### DIFF
--- a/lib/cvss_suite.rb
+++ b/lib/cvss_suite.rb
@@ -27,7 +27,12 @@ module CvssSuite
   def self.new(vector)
     return InvalidCvss.new unless vector.is_a? String
 
-    @vector_string = vector
+    if vector.frozen?
+      @vector_string = vector.dup
+    else
+      @vector_string = vector
+    end
+
     case version
     when 2
       Cvss2.new(prepare_vector(@vector_string))

--- a/lib/cvss_suite/cvss40/cvss40_calc_helper.rb
+++ b/lib/cvss_suite/cvss40/cvss40_calc_helper.rb
@@ -351,7 +351,7 @@ module CvssSuite
     end
 
     def concat_and_stringify(first, second, third, fourth, fifth, sixth)
-      ''.concat(first.to_s, second.to_s, third.to_s, fourth.to_s, fifth.to_s, sixth.to_s)
+      String.new.concat(first.to_s, second.to_s, third.to_s, fourth.to_s, fifth.to_s, sixth.to_s)
     end
 
     def sum_or_nil(values)


### PR DESCRIPTION


## Proposed changes

In the future Ruby will warn for when mutating strings that are not marked as mutable. You can find and fix these warnings by specifying RUBYOPT="--enable-frozen-string-literal" and fixing the errors that appear.

This PR updates cvss to pass all tests with that option enabled.

## Types of changes

Ruby Compatibility

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)