### PR TITLE
Expose impact and exploitability sub-scores

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Improvements
+* Expose impact and exploitability sub-scores. (@jgarber-cisco)
+
 ## [4.0.0] - 2024-08-31
 
 ### Breaking Changes

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -13,6 +13,7 @@ Contributors:
 - Brandyn Phelps <https://github.com/brphelps>
 - Karim ElGhandour <https://github.com/kghandour>
 - Adam Hess <https://github.com/HParker>
+- Jason Garber <https://github.com/jgarber>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/lib/cvss_suite/cvss2/cvss2_base.rb
+++ b/lib/cvss_suite/cvss2/cvss2_base.rb
@@ -30,6 +30,14 @@ module CvssSuite
       ((0.6 * impact) + (0.4 * exploitability) - 1.5) * additional_impact
     end
 
+    def impact_subscore
+      calc_impact.round(1)
+    end
+
+    def exploitability_subscore
+      calc_exploitability.round(1)
+    end
+
     private
 
     def init_properties
@@ -65,7 +73,7 @@ module CvssSuite
                                                    { name: 'Complete', abbreviation: 'C', weight: 0.66 }]))
     end
 
-    def calc_impact(sr_cr_score, sr_ir_score, sr_ar_score)
+    def calc_impact(sr_cr_score = 1, sr_ir_score = 1, sr_ar_score = 1)
       confidentiality_score = 1 - @confidentiality_impact.score * sr_cr_score
       integrity_score = 1 - @integrity_impact.score * sr_ir_score
       availability_score = 1 - @availability_impact.score * sr_ar_score

--- a/lib/cvss_suite/cvss3/cvss3_base.rb
+++ b/lib/cvss_suite/cvss3/cvss3_base.rb
@@ -19,18 +19,8 @@ module CvssSuite
     ##
     # Returns score of this metric
     def score
-      privilege_score = Cvss3Helper.privileges_required_score @privileges_required, @scope
-
-      exploitability = 8.22 * @attack_vector.score * @attack_complexity.score *
-                       privilege_score * @user_interaction.score
-
-      isc_base = 1 - ((1 - @confidentiality.score) * (1 - @integrity.score) * (1 - @availability.score))
-
-      impact_sub_score = if @scope.selected_value[:name] == 'Changed'
-                           7.52 * (isc_base - 0.029) - 3.25 * (isc_base - 0.02)**15
-                         else
-                           6.42 * isc_base
-                         end
+      exploitability = calc_exploitability
+      impact_sub_score = calc_impact
 
       return 0 if impact_sub_score <= 0
 
@@ -39,6 +29,14 @@ module CvssSuite
       else
         [10, impact_sub_score + exploitability].min
       end
+    end
+
+    def impact_subscore
+      calc_impact.round(1)
+    end
+
+    def exploitability_subscore
+      calc_exploitability.round(1)
     end
 
     private
@@ -82,6 +80,23 @@ module CvssSuite
                                           values: [{ name: 'None', abbreviation: 'N', weight: 0.0 },
                                                    { name: 'Low', abbreviation: 'L', weight: 0.22 },
                                                    { name: 'High', abbreviation: 'H', weight: 0.56 }]))
+    end
+
+    def calc_exploitability
+      privilege_score = Cvss3Helper.privileges_required_score @privileges_required, @scope
+
+      8.22 * @attack_vector.score * @attack_complexity.score *
+        privilege_score * @user_interaction.score
+    end
+
+    def calc_impact
+      isc_base = 1 - ((1 - @confidentiality.score) * (1 - @integrity.score) * (1 - @availability.score))
+
+      if @scope.selected_value[:name] == 'Changed'
+        7.52 * (isc_base - 0.029) - 3.25 * (isc_base - 0.02)**15
+      else
+        6.42 * isc_base
+      end
     end
   end
 end

--- a/spec/cvss2/cvss2_spec.rb
+++ b/spec/cvss2/cvss2_spec.rb
@@ -38,49 +38,49 @@ describe CvssSuite::Cvss2 do
   describe 'valid cvss2' do
     subject { valid_cvss2 }
 
-    it_behaves_like 'a valid cvss vector', 2, 7.5, 7.5, 7.5, 7.5, 'High'
+    it_behaves_like 'a valid cvss vector', 2, 7.5, 6.4, 10.0, 7.5, 7.5, 7.5, 'High'
   end
 
   describe 'valid cvss2 enclosed with parenthesis' do
     subject { valid_cvss2_parenthesis }
 
-    it_behaves_like 'a valid cvss vector', 2, 7.5, 7.5, 7.5, 7.5, 'High'
+    it_behaves_like 'a valid cvss vector', 2, 7.5, 6.4, 10.0, 7.5, 7.5, 7.5, 'High'
   end
 
   describe 'valid cvss2 with temporal' do
     subject { valid_cvss2_temporal }
 
-    it_behaves_like 'a valid cvss vector', 2, 7.5, 5.5, 5.5, 5.5, 'Medium'
+    it_behaves_like 'a valid cvss vector', 2, 7.5, 6.4, 10.0, 5.5, 5.5, 5.5, 'Medium'
   end
 
   describe 'valid cvss2 with temporal enclosed with parenthesis' do
     subject { valid_cvss2_temporal_parenthesis }
 
-    it_behaves_like 'a valid cvss vector', 2, 7.5, 5.5, 5.5, 5.5, 'Medium'
+    it_behaves_like 'a valid cvss vector', 2, 7.5, 6.4, 10.0, 5.5, 5.5, 5.5, 'Medium'
   end
 
   describe 'valid cvss2 with environmental' do
     subject { valid_cvss2_environmental }
 
-    it_behaves_like 'a valid cvss vector', 2, 4.9, 4.9, 4.1, 4.1, 'Medium'
+    it_behaves_like 'a valid cvss vector', 2, 4.9, 6.4, 4.4, 4.9, 4.1, 4.1, 'Medium'
   end
 
   describe 'valid cvss2 with environmental enclosed with parenthesis' do
     subject { valid_cvss2_environmental_parenthesis }
 
-    it_behaves_like 'a valid cvss vector', 2, 4.9, 4.9, 4.1, 4.1, 'Medium'
+    it_behaves_like 'a valid cvss vector', 2, 4.9, 6.4, 4.4, 4.9, 4.1, 4.1, 'Medium'
   end
 
   describe 'valid cvss2 with temporal and environmental' do
     subject { valid_cvss2_temporal_environmental }
 
-    it_behaves_like 'a valid cvss vector', 2, 4.9, 3.6, 3.2, 3.2, 'Low'
+    it_behaves_like 'a valid cvss vector', 2, 4.9, 6.4, 4.4, 3.6, 3.2, 3.2, 'Low'
   end
 
   describe 'valid cvss2 with temporal and environmental enclosed with parenthesis' do
     subject { valid_cvss2_temporal_environmental_parenthesis }
 
-    it_behaves_like 'a valid cvss vector', 2, 4.9, 3.6, 3.2, 3.2, 'Low'
+    it_behaves_like 'a valid cvss vector', 2, 4.9, 6.4, 4.4, 3.6, 3.2, 3.2, 'Low'
   end
 
   describe 'invalid cvss2' do

--- a/spec/cvss3/cvss3_spec.rb
+++ b/spec/cvss3/cvss3_spec.rb
@@ -53,91 +53,92 @@ describe CvssSuite::Cvss3 do
   describe 'valid cvss3' do
     subject { valid_cvss3 }
 
-    it_behaves_like 'a valid cvss vector', 3.0, 4.2, 4.2, 4.2, 4.2, 'Medium'
+    it_behaves_like 'a valid cvss vector', 3.0, 4.2, 3.4, 0.8, 4.2, 4.2, 4.2, 'Medium'
   end
 
   describe 'valid reordered cvss3' do
     subject { valid_reordered_cvss3 }
 
-    it_behaves_like 'a valid cvss vector', 3.0, 4.2, 4.2, 4.2, 4.2, 'Medium'
+    it_behaves_like 'a valid cvss vector', 3.0, 4.2, 3.4, 0.8, 4.2, 4.2, 4.2, 'Medium'
   end
 
   describe 'valid cvss3 with base_score 10' do
     subject { valid_cvss3_base_score10 }
 
-    it_behaves_like 'a valid cvss vector', 3.0, 10.0, 8.7, 8.7, 8.7, 'High'
+    it_behaves_like 'a valid cvss vector', 3.0, 10.0, 6.0, 3.9, 8.7, 8.7, 8.7, 'High'
   end
 
   describe 'valid cvss3 with temporal_score 10' do
     subject { valid_cvss3_temporal_score10 }
 
-    it_behaves_like 'a valid cvss vector', 3.0, 10.0, 10.0, 10.0, 10.0, 'Critical'
+    it_behaves_like 'a valid cvss vector', 3.0, 10.0, 6.0, 3.9, 10.0, 10.0, 10.0, 'Critical'
   end
 
   describe 'valid cvss3 with temporal_round_up' do
     subject { valid_cvss3_temporal_round_up }
+    # FIXME: shouldn't this round down?
 
-    it_behaves_like 'a valid cvss vector', 3.0, 5.0, 4.7, 4.7, 4.7, 'Medium'
+    it_behaves_like 'a valid cvss vector', 3.0, 5.0, 4.7, 0.3, 4.7, 4.7, 4.7, 'Medium'
   end
 
   describe 'valid cvss3 with temporal' do
     subject { valid_cvss3_temporal }
 
-    it_behaves_like 'a valid cvss vector', 3.0, 4.0, 3.7, 3.7, 3.7, 'Low'
+    it_behaves_like 'a valid cvss vector', 3.0, 4.0, 1.4, 2.2, 3.7, 3.7, 3.7, 'Low'
   end
 
   describe 'valid incomplete cvss3 with temporal' do
     subject { valid_incomplete_cvss3_temporal }
 
-    it_behaves_like 'a valid cvss vector', 3.0, 4.0, 3.9, 3.9, 3.9, 'Low'
+    it_behaves_like 'a valid cvss vector', 3.0, 4.0, 1.4, 2.2, 3.9, 3.9, 3.9, 'Low'
   end
 
   describe 'valid reordered cvss3 with temporal' do
     subject { valid_reordered_cvss3_temporal }
 
-    it_behaves_like 'a valid cvss vector', 3.0, 4.0, 3.7, 3.7, 3.7, 'Low'
+    it_behaves_like 'a valid cvss vector', 3.0, 4.0, 1.4, 2.2, 3.7, 3.7, 3.7, 'Low'
   end
 
   describe 'valid cvss3 with environmental' do
     subject { valid_cvss3_environmental }
 
-    it_behaves_like 'a valid cvss vector', 3.0, 5.0, 5.0, 7.3, 7.3, 'High'
+    it_behaves_like 'a valid cvss vector', 3.0, 5.0, 3.7, 0.8, 5.0, 7.3, 7.3, 'High'
   end
 
   describe 'valid reordered cvss3 with environmental' do
     subject { valid_reordered_cvss3_environmental }
 
-    it_behaves_like 'a valid cvss vector', 3.0, 5.0, 5.0, 7.3, 7.3, 'High'
+    it_behaves_like 'a valid cvss vector', 3.0, 5.0, 3.7, 0.8, 5.0, 7.3, 7.3, 'High'
   end
 
   describe 'valid cvss3 with temporal and environmental' do
     subject { valid_cvss3_temporal_environmental }
 
-    it_behaves_like 'a valid cvss vector', 3.0, 5.0, 4.4, 7.3, 7.3, 'High'
+    it_behaves_like 'a valid cvss vector', 3.0, 5.0, 3.7, 0.8, 4.4, 7.3, 7.3, 'High'
   end
 
   describe 'valid cvss3 with temporal and environmental and partly not defined' do
     subject { valid_cvss3_temporal_environmental_partly_not_defined }
 
-    it_behaves_like 'a valid cvss vector', 3.0, 5.7, 5.5, 6.0, 6.0, 'Medium'
+    it_behaves_like 'a valid cvss vector', 3.0, 5.7, 4.7, 0.5, 5.5, 6.0, 6.0, 'Medium'
   end
 
   describe 'valid cvss3 with temporal and environmental and not defined' do
     subject { valid_cvss3_temporal_environmental_not_defined }
 
-    it_behaves_like 'a valid cvss vector', 3.0, 5.7, 5.5, 6.9, 6.9, 'Medium'
+    it_behaves_like 'a valid cvss vector', 3.0, 5.7, 4.7, 0.5, 5.5, 6.9, 6.9, 'Medium'
   end
 
   describe 'valid cvss3 with temporal and environmental and modified confidentiality low' do
     subject { valid_cvss3_temporal_environmental_modified_confidentiality_low }
 
-    it_behaves_like 'a valid cvss vector', 3.0, 10.0, 8.1, 5.6, 5.6, 'Medium'
+    it_behaves_like 'a valid cvss vector', 3.0, 10.0, 6.0, 3.9, 8.1, 5.6, 5.6, 'Medium'
   end
 
   describe 'valid cvss3 with temporal and environmental and modified confidentiality high' do
     subject { valid_cvss3_temporal_environmental_modified_confidentiality_high }
 
-    it_behaves_like 'a valid cvss vector', 3.0, 10.0, 8.1, 5.5, 5.5, 'Medium'
+    it_behaves_like 'a valid cvss vector', 3.0, 10.0, 6.0, 3.9, 8.1, 5.5, 5.5, 'Medium'
   end
 
   describe 'invalid cvss3' do

--- a/spec/cvss31/cvss31_spec.rb
+++ b/spec/cvss31/cvss31_spec.rb
@@ -52,91 +52,91 @@ describe CvssSuite::Cvss31 do
   describe 'valid cvss31' do
     subject { valid_cvss31 }
 
-    it_behaves_like 'a valid cvss vector', 3.1, 4.2, 4.2, 4.2, 4.2, 'Medium'
+    it_behaves_like 'a valid cvss vector', 3.1, 4.2, 3.4, 0.8, 4.2, 4.2, 4.2, 'Medium'
   end
 
   describe 'valid reordered cvss31' do
     subject { valid_reordered_cvss31 }
 
-    it_behaves_like 'a valid cvss vector', 3.1, 4.2, 4.2, 4.2, 4.2, 'Medium'
+    it_behaves_like 'a valid cvss vector', 3.1, 4.2, 3.4, 0.8, 4.2, 4.2, 4.2, 'Medium'
   end
 
   describe 'valid cvss31 with base_score 10' do
     subject { valid_cvss31_base_score10 }
 
-    it_behaves_like 'a valid cvss vector', 3.1, 10.0, 8.7, 8.7, 8.7, 'High'
+    it_behaves_like 'a valid cvss vector', 3.1, 10.0, 6.0, 3.9, 8.7, 8.7, 8.7, 'High'
   end
 
   describe 'valid cvss31 with temporal_score 10' do
     subject { valid_cvss31_temporal_score10 }
 
-    it_behaves_like 'a valid cvss vector', 3.1, 10.0, 10.0, 10.0, 10.0, 'Critical'
+    it_behaves_like 'a valid cvss vector', 3.1, 10.0, 6.0, 3.9, 10.0, 10.0, 10.0, 'Critical'
   end
 
   describe 'valid cvss31 with temporal_round_up' do
     subject { valid_cvss31_temporal_round_up }
 
-    it_behaves_like 'a valid cvss vector', 3.1, 5.0, 4.6, 4.6, 4.6, 'Medium'
+    it_behaves_like 'a valid cvss vector', 3.1, 5.0, 4.7, 0.3, 4.6, 4.6, 4.6, 'Medium'
   end
 
   describe 'valid cvss31 with temporal' do
     subject { valid_cvss31_temporal }
 
-    it_behaves_like 'a valid cvss vector', 3.1, 4.0, 3.7, 3.7, 3.7, 'Low'
+    it_behaves_like 'a valid cvss vector', 3.1, 4.0, 1.4, 2.2, 3.7, 3.7, 3.7, 'Low'
   end
 
   describe 'valid incomplete cvss31 with temporal' do
     subject { valid_incomplete_cvss31_temporal }
 
-    it_behaves_like 'a valid cvss vector', 3.1, 4.0, 3.9, 3.9, 3.9, 'Low'
+    it_behaves_like 'a valid cvss vector', 3.1, 4.0, 1.4, 2.2, 3.9, 3.9, 3.9, 'Low'
   end
 
   describe 'valid reordered cvss31 with temporal' do
     subject { valid_reordered_cvss31_temporal }
 
-    it_behaves_like 'a valid cvss vector', 3.1, 4.0, 3.7, 3.7, 3.7, 'Low'
+    it_behaves_like 'a valid cvss vector', 3.1, 4.0, 1.4, 2.2, 3.7, 3.7, 3.7, 'Low'
   end
 
   describe 'valid cvss31 with environmental' do
     subject { valid_cvss31_environmental }
 
-    it_behaves_like 'a valid cvss vector', 3.1, 5.0, 5.0, 7.3, 7.3, 'High'
+    it_behaves_like 'a valid cvss vector', 3.1, 5.0, 3.7, 0.8, 5.0, 7.3, 7.3, 'High'
   end
 
   describe 'valid reordered cvss31 with environmental' do
     subject { valid_reordered_cvss31_environmental }
 
-    it_behaves_like 'a valid cvss vector', 3.1, 5.0, 5.0, 7.3, 7.3, 'High'
+    it_behaves_like 'a valid cvss vector', 3.1, 5.0, 3.7, 0.8, 5.0, 7.3, 7.3, 'High'
   end
 
   describe 'valid cvss31 with temporal and environmental' do
     subject { valid_cvss31_temporal_environmental }
 
-    it_behaves_like 'a valid cvss vector', 3.1, 5.0, 4.4, 7.4, 7.4, 'High'
+    it_behaves_like 'a valid cvss vector', 3.1, 5.0, 3.7, 0.8, 4.4, 7.4, 7.4, 'High'
   end
 
   describe 'valid cvss31 with temporal and environmental and partly not defined' do
     subject { valid_cvss31_temporal_environmental_partly_not_defined }
 
-    it_behaves_like 'a valid cvss vector', 3.1, 5.7, 5.5, 6.0, 6.0, 'Medium'
+    it_behaves_like 'a valid cvss vector', 3.1, 5.7, 4.7, 0.5, 5.5, 6.0, 6.0, 'Medium'
   end
 
   describe 'valid cvss31 with temporal and environmental and not defined' do
     subject { valid_cvss31_temporal_environmental_not_defined }
 
-    it_behaves_like 'a valid cvss vector', 3.1, 5.7, 5.5, 6.9, 6.9, 'Medium'
+    it_behaves_like 'a valid cvss vector', 3.1, 5.7, 4.7, 0.5, 5.5, 6.9, 6.9, 'Medium'
   end
 
   describe 'valid cvss31 with temporal and environmental and modified confidentiality low' do
     subject { valid_cvss31_temporal_environmental_modified_confidentiality_low }
 
-    it_behaves_like 'a valid cvss vector', 3.1, 10.0, 8.1, 5.6, 5.6, 'Medium'
+    it_behaves_like 'a valid cvss vector', 3.1, 10.0, 6.0, 3.9, 8.1, 5.6, 5.6, 'Medium'
   end
 
   describe 'valid cvss31 with temporal and environmental and modified confidentiality high' do
     subject { valid_cvss31_temporal_environmental_modified_confidentiality_high }
 
-    it_behaves_like 'a valid cvss vector', 3.1, 10.0, 8.1, 5.6, 5.6, 'Medium'
+    it_behaves_like 'a valid cvss vector', 3.1, 10.0, 6.0, 3.9, 8.1, 5.6, 5.6, 'Medium'
   end
 
   describe 'invalid cvss31' do

--- a/spec/shared_examples.rb
+++ b/spec/shared_examples.rb
@@ -3,8 +3,8 @@
 # This work is licensed under the terms of the MIT license.
 # See the LICENSE.md file in the top-level directory.
 
-shared_examples 'a valid cvss vector' do |version, base_score, temporal_score,
-                                          environmental_score, overall_score, severity|
+shared_examples 'a valid cvss vector' do |version, base_score, impact_subscore, exploitability_subscore, # rubocop:disable Metrics/ParameterLists
+                                          temporal_score, environmental_score, overall_score, severity|
   it { is_expected.to be_valid }
   its(:valid?) { is_expected.to be(true) }
   its(:version) { is_expected.to eql(version) }
@@ -13,6 +13,12 @@ shared_examples 'a valid cvss vector' do |version, base_score, temporal_score,
   its(:environmental_score) { is_expected.to eql(environmental_score) }
   its(:overall_score) { is_expected.to eql(overall_score) }
   its(:severity) { is_expected.to eql(severity) }
+  it 'exposes the impact sub-score' do
+    expect(subject.base.impact_subscore).to eq(impact_subscore)
+  end
+  it 'exposes the exploitability sub-score' do
+    expect(subject.base.exploitability_subscore).to eq(exploitability_subscore)
+  end
 end
 
 shared_examples 'a invalid cvss vector with version' do |version|


### PR DESCRIPTION
## Proposed changes

Some applications require reporting the impact subscore and the exploitability subscore, which were previously internal calculations.

<img width="1409" alt="Screenshot 2025-04-15 at 11 34 09 PM" src="https://github.com/user-attachments/assets/ce1d9b3c-d719-4d18-8130-6b22dc92d9d4" />

```ruby
irb(main):002> cvss = CvssSuite.new('(AV:A/AC:M/Au:S/C:P/I:P/A:P/E:POC/RL:TF/RC:UC/CDP:H/TD:H/CR:H/IR:H/AR:H)')
=> 
#<CvssSuite::Cvss2:0x000000010b6bc1d0
...
irb(main):003> cvss.base_score
=> 4.9
irb(main):004> cvss.base.impact_subscore
=> 6.4
irb(main):005> cvss.base.exploitability_subscore
=> 4.4
```

## Types of changes

What types of changes does your code introduce to CvssSuite?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] Unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

- Subscore could be `sub score`, `sub-score`, or `subscore`. It appears those various ways in the [first.org documentation](https://www.first.org/cvss/). I prefer `subscore` because the [NIST calculators](https://nvd.nist.gov/vuln-metrics/cvss/v2-calculator) [use it](https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator) thus, but go with whatever you like.
- I chose to keep your shared examples and just add the two scores to every example, plugging the vector into the NIST calculators by hand and typing in the resulting scores. It _is_ a lot of parameters to the shared example, as RuboCop warns us. I'm very open to alternatives.
- I'm not doing anything with the environment metric's modified impact because it's not a requirement of our application.
- Obviously this only applies to v2-3.1, since 4.0 doesn't have subscores.

