### PR TITLE
Refactor score method and add round_up function

### DIFF
--- a/lib/cvss_suite/cvss31/cvss31_base.rb
+++ b/lib/cvss_suite/cvss31/cvss31_base.rb
@@ -23,13 +23,15 @@ module CvssSuite
       exploitability = calc_exploitability
       impact_sub_score = calc_impact
 
-      return 0 if impact_sub_score <= 0
+      return 0.0 if impact_sub_score <= 0
 
-      if @scope.selected_value[:name] == 'Changed'
-        [10, 1.08 * (impact_sub_score + exploitability)].min
-      else
-        [10, impact_sub_score + exploitability].min
-      end
+      raw_score = if @scope.selected_value[:name] == 'Changed'
+                    [10, 1.08 * (impact_sub_score + exploitability)].min
+                  else
+                    [10, impact_sub_score + exploitability].min
+                  end
+
+      round_up(raw_score)
     end
 
     def impact_subscore
@@ -97,6 +99,26 @@ module CvssSuite
         7.52 * (isc_base - 0.029) - 3.25 * (isc_base - 0.02)**15
       else
         6.42 * isc_base
+      end
+    end
+
+    ##
+    # Implements the CVSS 3.1 roundup function as specified in Appendix A
+    # of the CVSS 3.1 specification. This function rounds up to 1 decimal place
+    # using integer arithmetic to avoid floating point errors.
+    #
+    # @param input [Float] The value to round up
+    # @return [Float] The rounded value
+    def round_up(input)
+      # Multiply by 100,000 and round to nearest integer to avoid floating point issues
+      int_input = (input * 100_000).round
+
+      # If the last 4 digits are 0, no rounding up is needed
+      if int_input % 10_000 == 0
+        int_input / 100_000.0
+      else
+        # Otherwise, round up to the next 0.1
+        ((int_input / 10_000).floor + 1) / 10.0
       end
     end
   end


### PR DESCRIPTION
## Proposed changes

Refactor score method to return float and add rounding functionality to align with https://www.first.org/cvss/v3-1/specification-document#Appendix-A---Floating-Point-Rounding .

### Problem
The CVSS 3.1 implementation was missing the required `roundup` function specified in the CVSS 3.1 specification (Appendix A), causing certain vectors to produce incorrect scores. 

Most notably, the vector `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H` was returning a score of 10.0 instead of the correct 9.9.

### Root Cause
The CVSS 3.1 specification requires a specific rounding function that rounds up to 1 decimal place using integer arithmetic to avoid floating-point precision issues. The current implementation was returning raw calculated values without applying this mandatory rounding step.

### Solution
Implemented the `round_up` function following the CVSS 3.1 specification Appendix A:
- Multiplies input by 100,000 and rounds to nearest integer
- Uses integer arithmetic to avoid floating-point errors
- Rounds up to the next 0.1 unless already at a 0.1 boundary

## Types of changes

What types of changes does your code introduce to CvssSuite?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)