### PR TITLE
Relaxes bigdecimal dependency to allow for greater versions

### DIFF
--- a/cvss_suite.gemspec
+++ b/cvss_suite.gemspec
@@ -37,7 +37,7 @@ in version 4.0, 3.1, 3.0 and 2.'
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'bigdecimal', '~> 3.1.8'
+  spec.add_dependency "bigdecimal", ">= 3.1.8"
 
   spec.add_development_dependency 'bundler', '2.4.22'
   spec.add_development_dependency 'csv', '~> 3.3'


### PR DESCRIPTION
## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

We are trying to update `cvss-suite` gem to latest version with constaint **"~> 4.0"** (current constraint "~> 3.3")

Following is example current Gemfile 

`gem "cvss-suite", "~> 3.3"`

Also, transitive dep `bigdecimal` is pinned to (3.3.1) in gemfile.lock

 i.e.   `bigdecimal (3.3.1)`

We noticed after updating and running `cvss-suite` with `bundle update cvss-suite` , the `bigdecimal` is downgraded to `3.1.9`
This is likely due to strict constraint `spec.add_dependency 'bigdecimal', '~> 3.1.8'`. This PR is to relax the constraints so that the bigdecimal is is not downgraded from `3.3.1` to `3.1.8`

What types of changes does your code introduce to CvssSuite?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
