### PR TITLE
Fixes score discrepency due to temporal and environmental metric

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -45,6 +45,7 @@ Metrics/BlockLength:
     - 'spec/cvss3/cvss3_spec.rb'
     - 'spec/cvss31/cvss31_spec.rb'
     - 'spec/cvss40/cvss40_spec.rb'
+    - 'spec/cvss_metric_spec.rb'
 
 Style/IfUnlessModifier:
   Exclude:

--- a/lib/cvss_suite/cvss_31_and_before.rb
+++ b/lib/cvss_suite/cvss_31_and_before.rb
@@ -40,8 +40,8 @@ module CvssSuite
     # Returns the Overall Score of the CVSS vector.
     def overall_score
       check_validity
-      return temporal_score if @temporal.valid? && !@environmental.valid?
-      return environmental_score if @environmental.valid?
+      return temporal_score if @temporal.explicitly_provided? && !@environmental.explicitly_provided?
+      return environmental_score if @environmental.explicitly_provided?
 
       base_score
     end

--- a/lib/cvss_suite/cvss_metric.rb
+++ b/lib/cvss_suite/cvss_metric.rb
@@ -25,6 +25,17 @@ module CvssSuite
     end
 
     ##
+    # Returns if any property in this metric was explicitly provided
+    # (i.e., set to a value other than the default 'X' or 'ND').
+    def explicitly_provided?
+      @properties.any? do |property|
+        property.valid? &&
+          property.selected_value[:abbreviation] != 'X' &&
+          property.selected_value[:abbreviation] != 'ND'
+      end
+    end
+
+    ##
     # Returns number of properties for this metric.
     def count
       @properties.count

--- a/spec/cvss3/cvss3_spec.rb
+++ b/spec/cvss3/cvss3_spec.rb
@@ -36,6 +36,13 @@ describe CvssSuite::Cvss3 do
     CvssSuite.new('CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H/E:U/RL:T/RC:U/CR:L/IR:L/AR:H/MAV:P/MAC:H/MPR:H/MUI:R/MS:C/MC:H/MI:H/MA:H') # rubocop:disable Layout/LineLength
   end
 
+  # Base-only vectors with Scope: Changed (issue #58)
+  let(:valid_cvss3_base_only_scope_changed_1) { CvssSuite.new('CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H') }
+  let(:valid_cvss3_base_only_scope_changed_2) { CvssSuite.new('CVSS:3.0/AV:P/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H') }
+  let(:valid_cvss3_base_only_scope_changed_3) { CvssSuite.new('CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:H') }
+  # Temporal-only with Scope: Changed (issue #58)
+  let(:valid_cvss3_temporal_only_scope_changed) { CvssSuite.new('CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H/E:H/RL:T/RC:C') }
+
   let(:invalid_cvss3_with_version) { CvssSuite.new('CVSS:3.0/AV:L/AC:') }
   let(:invalid_cvss3_not_defined) { CvssSuite.new('CVSS:3.0/AV:X/AC:H/PR:L/UI:R/S:U/C:L/I:N/A:H') }
   let(:invalid_cvss3_missing_metric) { CvssSuite.new('CVSS:3.0/AV:L/AC:H/PR:L/UI:R/S:U/C:L/I:L') }
@@ -139,6 +146,36 @@ describe CvssSuite::Cvss3 do
     subject { valid_cvss3_temporal_environmental_modified_confidentiality_high }
 
     it_behaves_like 'a valid cvss vector', 3.0, 10.0, 6.05, 3.89, 8.1, 5.5, 5.5, 'Medium'
+  end
+
+  # Issue #58: overall_score should equal base_score for base-only vectors with Scope: Changed
+  describe 'base-only vectors with Scope: Changed (issue #58)' do
+    it 'CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H overall_score equals base_score (9.6)' do
+      cvss = valid_cvss3_base_only_scope_changed_1
+      expect(cvss.overall_score).to eql(cvss.base_score)
+      expect(cvss.base_score).to eql(9.6)
+    end
+
+    it 'CVSS:3.0/AV:P/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H overall_score equals base_score (7.6)' do
+      cvss = valid_cvss3_base_only_scope_changed_2
+      expect(cvss.overall_score).to eql(cvss.base_score)
+      expect(cvss.base_score).to eql(7.6)
+    end
+
+    it 'CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:H overall_score equals base_score (9.0)' do
+      cvss = valid_cvss3_base_only_scope_changed_3
+      expect(cvss.overall_score).to eql(cvss.base_score)
+      expect(cvss.base_score).to eql(9.0)
+    end
+  end
+
+  # Issue #58: overall_score should equal temporal_score when only temporal metrics are provided
+  describe 'temporal-only vector with Scope: Changed (issue #58)' do
+    it 'CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H/E:H/RL:T/RC:C overall_score equals temporal_score (9.3)' do
+      cvss = valid_cvss3_temporal_only_scope_changed
+      expect(cvss.overall_score).to eql(cvss.temporal_score)
+      expect(cvss.temporal_score).to eql(9.3)
+    end
   end
 
   describe 'invalid cvss3' do

--- a/spec/cvss3/cvss3_spec.rb
+++ b/spec/cvss3/cvss3_spec.rb
@@ -37,11 +37,13 @@ describe CvssSuite::Cvss3 do
   end
 
   # Base-only vectors with Scope: Changed (issue #58)
-  let(:valid_cvss3_base_only_scope_changed_1) { CvssSuite.new('CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H') }
-  let(:valid_cvss3_base_only_scope_changed_2) { CvssSuite.new('CVSS:3.0/AV:P/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H') }
-  let(:valid_cvss3_base_only_scope_changed_3) { CvssSuite.new('CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:H') }
+  let(:valid_cvss3_base_only_scope_changed1) { CvssSuite.new('CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H') }
+  let(:valid_cvss3_base_only_scope_changed2) { CvssSuite.new('CVSS:3.0/AV:P/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H') }
+  let(:valid_cvss3_base_only_scope_changed3) { CvssSuite.new('CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:H') }
   # Temporal-only with Scope: Changed (issue #58)
-  let(:valid_cvss3_temporal_only_scope_changed) { CvssSuite.new('CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H/E:H/RL:T/RC:C') }
+  let(:valid_cvss3_temporal_only_scope_changed) do
+    CvssSuite.new('CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H/E:H/RL:T/RC:C')
+  end
 
   let(:invalid_cvss3_with_version) { CvssSuite.new('CVSS:3.0/AV:L/AC:') }
   let(:invalid_cvss3_not_defined) { CvssSuite.new('CVSS:3.0/AV:X/AC:H/PR:L/UI:R/S:U/C:L/I:N/A:H') }
@@ -151,19 +153,19 @@ describe CvssSuite::Cvss3 do
   # Issue #58: overall_score should equal base_score for base-only vectors with Scope: Changed
   describe 'base-only vectors with Scope: Changed (issue #58)' do
     it 'CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H overall_score equals base_score (9.6)' do
-      cvss = valid_cvss3_base_only_scope_changed_1
+      cvss = valid_cvss3_base_only_scope_changed1
       expect(cvss.overall_score).to eql(cvss.base_score)
       expect(cvss.base_score).to eql(9.6)
     end
 
     it 'CVSS:3.0/AV:P/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H overall_score equals base_score (7.6)' do
-      cvss = valid_cvss3_base_only_scope_changed_2
+      cvss = valid_cvss3_base_only_scope_changed2
       expect(cvss.overall_score).to eql(cvss.base_score)
       expect(cvss.base_score).to eql(7.6)
     end
 
     it 'CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:H overall_score equals base_score (9.0)' do
-      cvss = valid_cvss3_base_only_scope_changed_3
+      cvss = valid_cvss3_base_only_scope_changed3
       expect(cvss.overall_score).to eql(cvss.base_score)
       expect(cvss.base_score).to eql(9.0)
     end

--- a/spec/cvss31/cvss31_spec.rb
+++ b/spec/cvss31/cvss31_spec.rb
@@ -35,6 +35,22 @@ describe CvssSuite::Cvss31 do
   let(:valid_cvss31_temporal_environmental_modified_confidentiality_high) do
     CvssSuite.new('CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H/E:U/RL:T/RC:U/CR:L/IR:L/AR:H/MAV:P/MAC:H/MPR:H/MUI:R/MS:C/MC:H/MI:H/MA:H') # rubocop:disable Layout/LineLength
   end
+  # Base-only vectors with Scope: Changed (issue #58)
+  let(:valid_cvss31_base_only_scope_changed_1) { CvssSuite.new('CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H') }
+  let(:valid_cvss31_base_only_scope_changed_2) { CvssSuite.new('CVSS:3.1/AV:P/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H') }
+  let(:valid_cvss31_base_only_scope_changed_3) { CvssSuite.new('CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:H') }
+  let(:valid_cvss31_base_only_scope_changed_4) { CvssSuite.new('CVSS:3.1/AV:A/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H') }
+  let(:valid_cvss31_base_only_scope_changed_5) { CvssSuite.new('CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:H/I:H/A:H') }
+  # Base-only with Scope: Unchanged (sanity check — should also return base_score)
+  let(:valid_cvss31_base_only_scope_unchanged) { CvssSuite.new('CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H') }
+  # Temporal-only with Scope: Changed (issue #58)
+  let(:valid_cvss31_temporal_only_scope_changed_1) { CvssSuite.new('CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H/E:H/RL:T/RC:C') }
+  let(:valid_cvss31_temporal_only_scope_changed_2) { CvssSuite.new('CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H/E:P/RL:O/RC:R') }
+  # Environmental-only with Scope: Changed (issue #58)
+  let(:valid_cvss31_env_only_scope_changed) do
+    CvssSuite.new('CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H/CR:L/IR:M/AR:H/MAV:N/MAC:H/MPR:N/MUI:R/MS:U/MC:N/MI:L/MA:H') # rubocop:disable Layout/LineLength
+  end
+
   let(:invalid_cvss31_with_version) { CvssSuite.new('CVSS:3.1/AV:L/AC:') }
   let(:invalid_cvss31_not_defined) { CvssSuite.new('CVSS:3.1/AV:X/AC:H/PR:L/UI:R/S:U/C:L/I:N/A:H') }
   let(:invalid_cvss31_missing_metric) { CvssSuite.new('CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:U/C:L/I:L') }
@@ -137,6 +153,72 @@ describe CvssSuite::Cvss31 do
     subject { valid_cvss31_temporal_environmental_modified_confidentiality_high }
 
     it_behaves_like 'a valid cvss vector', 3.1, 10.0, 6.05, 3.89, 8.1, 5.6, 5.6, 'Medium'
+  end
+
+  # Issue #58: overall_score should equal base_score for base-only vectors with Scope: Changed
+  describe 'base-only vectors with Scope: Changed (issue #58)' do
+    it 'CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H overall_score equals base_score (9.6)' do
+      cvss = valid_cvss31_base_only_scope_changed_1
+      expect(cvss.overall_score).to eql(cvss.base_score)
+      expect(cvss.base_score).to eql(9.6)
+    end
+
+    it 'CVSS:3.1/AV:P/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H overall_score equals base_score (7.6)' do
+      cvss = valid_cvss31_base_only_scope_changed_2
+      expect(cvss.overall_score).to eql(cvss.base_score)
+      expect(cvss.base_score).to eql(7.6)
+    end
+
+    it 'CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:H overall_score equals base_score (9.0)' do
+      cvss = valid_cvss31_base_only_scope_changed_3
+      expect(cvss.overall_score).to eql(cvss.base_score)
+      expect(cvss.base_score).to eql(9.0)
+    end
+
+    it 'CVSS:3.1/AV:A/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H overall_score equals base_score (8.8)' do
+      cvss = valid_cvss31_base_only_scope_changed_4
+      expect(cvss.overall_score).to eql(cvss.base_score)
+      expect(cvss.base_score).to eql(8.8)
+    end
+
+    it 'CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:H/I:H/A:H overall_score equals base_score (9.0)' do
+      cvss = valid_cvss31_base_only_scope_changed_5
+      expect(cvss.overall_score).to eql(cvss.base_score)
+      expect(cvss.base_score).to eql(9.0)
+    end
+  end
+
+  # Issue #58: overall_score should equal base_score for base-only S:U vectors too
+  describe 'base-only vector with Scope: Unchanged (issue #58 sanity check)' do
+    it 'CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H overall_score equals base_score (8.8)' do
+      cvss = valid_cvss31_base_only_scope_unchanged
+      expect(cvss.overall_score).to eql(cvss.base_score)
+      expect(cvss.base_score).to eql(8.8)
+    end
+  end
+
+  # Issue #58: overall_score should equal temporal_score when only temporal metrics are provided
+  describe 'temporal-only vectors with Scope: Changed (issue #58)' do
+    it 'CVSS:3.1/.../E:H/RL:T/RC:C overall_score equals temporal_score (9.3)' do
+      cvss = valid_cvss31_temporal_only_scope_changed_1
+      expect(cvss.overall_score).to eql(cvss.temporal_score)
+      expect(cvss.temporal_score).to eql(9.3)
+    end
+
+    it 'CVSS:3.1/.../E:P/RL:O/RC:R overall_score equals temporal_score (8.3)' do
+      cvss = valid_cvss31_temporal_only_scope_changed_2
+      expect(cvss.overall_score).to eql(cvss.temporal_score)
+      expect(cvss.temporal_score).to eql(8.3)
+    end
+  end
+
+  # Issue #58: overall_score should equal environmental_score when only env metrics are provided
+  describe 'environmental-only vector with Scope: Changed (issue #58)' do
+    it 'overall_score equals environmental_score (7.3)' do
+      cvss = valid_cvss31_env_only_scope_changed
+      expect(cvss.overall_score).to eql(cvss.environmental_score)
+      expect(cvss.environmental_score).to eql(7.3)
+    end
   end
 
   describe 'invalid cvss31' do

--- a/spec/cvss31/cvss31_spec.rb
+++ b/spec/cvss31/cvss31_spec.rb
@@ -36,16 +36,20 @@ describe CvssSuite::Cvss31 do
     CvssSuite.new('CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H/E:U/RL:T/RC:U/CR:L/IR:L/AR:H/MAV:P/MAC:H/MPR:H/MUI:R/MS:C/MC:H/MI:H/MA:H') # rubocop:disable Layout/LineLength
   end
   # Base-only vectors with Scope: Changed (issue #58)
-  let(:valid_cvss31_base_only_scope_changed_1) { CvssSuite.new('CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H') }
-  let(:valid_cvss31_base_only_scope_changed_2) { CvssSuite.new('CVSS:3.1/AV:P/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H') }
-  let(:valid_cvss31_base_only_scope_changed_3) { CvssSuite.new('CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:H') }
-  let(:valid_cvss31_base_only_scope_changed_4) { CvssSuite.new('CVSS:3.1/AV:A/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H') }
-  let(:valid_cvss31_base_only_scope_changed_5) { CvssSuite.new('CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:H/I:H/A:H') }
+  let(:valid_cvss31_base_only_scope_changed1) { CvssSuite.new('CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H') }
+  let(:valid_cvss31_base_only_scope_changed2) { CvssSuite.new('CVSS:3.1/AV:P/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H') }
+  let(:valid_cvss31_base_only_scope_changed3) { CvssSuite.new('CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:H') }
+  let(:valid_cvss31_base_only_scope_changed4) { CvssSuite.new('CVSS:3.1/AV:A/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H') }
+  let(:valid_cvss31_base_only_scope_changed5) { CvssSuite.new('CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:H/I:H/A:H') }
   # Base-only with Scope: Unchanged (sanity check — should also return base_score)
   let(:valid_cvss31_base_only_scope_unchanged) { CvssSuite.new('CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H') }
   # Temporal-only with Scope: Changed (issue #58)
-  let(:valid_cvss31_temporal_only_scope_changed_1) { CvssSuite.new('CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H/E:H/RL:T/RC:C') }
-  let(:valid_cvss31_temporal_only_scope_changed_2) { CvssSuite.new('CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H/E:P/RL:O/RC:R') }
+  let(:valid_cvss31_temporal_only_scope_changed1) do
+    CvssSuite.new('CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H/E:H/RL:T/RC:C')
+  end
+  let(:valid_cvss31_temporal_only_scope_changed2) do
+    CvssSuite.new('CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H/E:P/RL:O/RC:R')
+  end
   # Environmental-only with Scope: Changed (issue #58)
   let(:valid_cvss31_env_only_scope_changed) do
     CvssSuite.new('CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H/CR:L/IR:M/AR:H/MAV:N/MAC:H/MPR:N/MUI:R/MS:U/MC:N/MI:L/MA:H') # rubocop:disable Layout/LineLength
@@ -158,31 +162,31 @@ describe CvssSuite::Cvss31 do
   # Issue #58: overall_score should equal base_score for base-only vectors with Scope: Changed
   describe 'base-only vectors with Scope: Changed (issue #58)' do
     it 'CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H overall_score equals base_score (9.6)' do
-      cvss = valid_cvss31_base_only_scope_changed_1
+      cvss = valid_cvss31_base_only_scope_changed1
       expect(cvss.overall_score).to eql(cvss.base_score)
       expect(cvss.base_score).to eql(9.6)
     end
 
     it 'CVSS:3.1/AV:P/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H overall_score equals base_score (7.6)' do
-      cvss = valid_cvss31_base_only_scope_changed_2
+      cvss = valid_cvss31_base_only_scope_changed2
       expect(cvss.overall_score).to eql(cvss.base_score)
       expect(cvss.base_score).to eql(7.6)
     end
 
     it 'CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:H overall_score equals base_score (9.0)' do
-      cvss = valid_cvss31_base_only_scope_changed_3
+      cvss = valid_cvss31_base_only_scope_changed3
       expect(cvss.overall_score).to eql(cvss.base_score)
       expect(cvss.base_score).to eql(9.0)
     end
 
     it 'CVSS:3.1/AV:A/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H overall_score equals base_score (8.8)' do
-      cvss = valid_cvss31_base_only_scope_changed_4
+      cvss = valid_cvss31_base_only_scope_changed4
       expect(cvss.overall_score).to eql(cvss.base_score)
       expect(cvss.base_score).to eql(8.8)
     end
 
     it 'CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:H/I:H/A:H overall_score equals base_score (9.0)' do
-      cvss = valid_cvss31_base_only_scope_changed_5
+      cvss = valid_cvss31_base_only_scope_changed5
       expect(cvss.overall_score).to eql(cvss.base_score)
       expect(cvss.base_score).to eql(9.0)
     end
@@ -200,13 +204,13 @@ describe CvssSuite::Cvss31 do
   # Issue #58: overall_score should equal temporal_score when only temporal metrics are provided
   describe 'temporal-only vectors with Scope: Changed (issue #58)' do
     it 'CVSS:3.1/.../E:H/RL:T/RC:C overall_score equals temporal_score (9.3)' do
-      cvss = valid_cvss31_temporal_only_scope_changed_1
+      cvss = valid_cvss31_temporal_only_scope_changed1
       expect(cvss.overall_score).to eql(cvss.temporal_score)
       expect(cvss.temporal_score).to eql(9.3)
     end
 
     it 'CVSS:3.1/.../E:P/RL:O/RC:R overall_score equals temporal_score (8.3)' do
-      cvss = valid_cvss31_temporal_only_scope_changed_2
+      cvss = valid_cvss31_temporal_only_scope_changed2
       expect(cvss.overall_score).to eql(cvss.temporal_score)
       expect(cvss.temporal_score).to eql(8.3)
     end

--- a/spec/cvss_metric_spec.rb
+++ b/spec/cvss_metric_spec.rb
@@ -1,0 +1,106 @@
+# CVSS-Suite, a Ruby gem to manage the CVSS vector
+#
+# This work is licensed under the terms of the MIT license.
+# See the LICENSE.md file in the top-level directory.
+
+require_relative 'spec_helper'
+
+describe CvssSuite::CvssMetric, '#explicitly_provided?' do
+  context 'with a CVSS 3.1 base-only vector' do
+    let(:cvss) { CvssSuite.new('CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H') }
+
+    it 'base metric is explicitly provided' do
+      expect(cvss.base.explicitly_provided?).to be true
+    end
+
+    it 'temporal metric is not explicitly provided' do
+      expect(cvss.temporal.explicitly_provided?).to be false
+    end
+
+    it 'environmental metric is not explicitly provided' do
+      expect(cvss.environmental.explicitly_provided?).to be false
+    end
+  end
+
+  context 'with a CVSS 3.1 vector including temporal metrics' do
+    let(:cvss) { CvssSuite.new('CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H/E:H/RL:T/RC:C') }
+
+    it 'temporal metric is explicitly provided' do
+      expect(cvss.temporal.explicitly_provided?).to be true
+    end
+
+    it 'environmental metric is not explicitly provided' do
+      expect(cvss.environmental.explicitly_provided?).to be false
+    end
+  end
+
+  context 'with a CVSS 3.1 vector including environmental metrics' do
+    let(:cvss) do
+      CvssSuite.new('CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H/CR:L/IR:M/AR:H/MAV:N/MAC:H/MPR:N/MUI:R/MS:U/MC:N/MI:L/MA:H') # rubocop:disable Layout/LineLength
+    end
+
+    it 'temporal metric is not explicitly provided' do
+      expect(cvss.temporal.explicitly_provided?).to be false
+    end
+
+    it 'environmental metric is explicitly provided' do
+      expect(cvss.environmental.explicitly_provided?).to be true
+    end
+  end
+
+  context 'with a CVSS 3.1 vector including temporal and environmental metrics' do
+    let(:cvss) do
+      CvssSuite.new('CVSS:3.1/AV:L/AC:H/PR:L/UI:R/S:C/C:L/I:L/A:L/E:P/RL:W/RC:R/CR:L/IR:M/AR:H/MAV:N/MAC:H/MPR:N/MUI:R/MS:C/MC:N/MI:L/MA:H') # rubocop:disable Layout/LineLength
+    end
+
+    it 'temporal metric is explicitly provided' do
+      expect(cvss.temporal.explicitly_provided?).to be true
+    end
+
+    it 'environmental metric is explicitly provided' do
+      expect(cvss.environmental.explicitly_provided?).to be true
+    end
+  end
+
+  context 'with a CVSS 3.1 vector with all environmental modifiers set to X' do
+    let(:cvss) do
+      CvssSuite.new('CVSS:3.1/AV:P/AC:L/PR:H/UI:N/S:C/C:N/I:L/A:H/E:X/RL:T/RC:C/CR:M/IR:L/AR:H/MAV:X/MAC:X/MPR:X/MUI:X/MS:X/MC:X/MI:X/MA:X') # rubocop:disable Layout/LineLength
+    end
+
+    it 'temporal metric is explicitly provided (RL:T, RC:C are non-default)' do
+      expect(cvss.temporal.explicitly_provided?).to be true
+    end
+
+    it 'environmental metric is explicitly provided (CR:M, IR:L, AR:H are non-default)' do
+      expect(cvss.environmental.explicitly_provided?).to be true
+    end
+  end
+
+  context 'with a CVSS 2 base-only vector' do
+    let(:cvss) { CvssSuite.new('AV:N/AC:L/Au:N/C:P/I:P/A:P') }
+
+    it 'base metric is explicitly provided' do
+      expect(cvss.base.explicitly_provided?).to be true
+    end
+
+    it 'temporal metric is not explicitly provided' do
+      expect(cvss.temporal.explicitly_provided?).to be false
+    end
+
+    it 'environmental metric is not explicitly provided' do
+      expect(cvss.environmental.explicitly_provided?).to be false
+    end
+  end
+
+  context 'with a CVSS 3.0 base-only vector' do
+    let(:cvss) { CvssSuite.new('CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H') }
+
+    it 'temporal metric is not explicitly provided' do
+      expect(cvss.temporal.explicitly_provided?).to be false
+    end
+
+    it 'environmental metric is not explicitly provided' do
+      expect(cvss.environmental.explicitly_provided?).to be false
+    end
+  end
+end


### PR DESCRIPTION
## Proposed changes

When a CVSS 3.0 or 3.1 vector contains only base metrics (no temporal or environmental metrics), overall_score incorrectly returns the environmental score instead of the base score. This produces scores that differ from the [NIST NVD Calculator](https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator) and the [FIRST CVSS Calculator](https://www.first.org/cvss/calculator/3.1). See [issue](https://github.com/0llirocks/cvss-suite/issues/58) 



### Test Coverage

#### `spec/cvss_metric_spec.rb` (new — 15 tests)

Unit tests for the new `CvssMetric#explicitly_provided?` method:

| Context | Assertions |
|---|---|
| CVSS 3.1 base-only vector | base → `true`, temporal → `false`, environmental → `false` |
| CVSS 3.1 with temporal metrics | temporal → `true`, environmental → `false` |
| CVSS 3.1 with environmental metrics | temporal → `false`, environmental → `true` |
| CVSS 3.1 with temporal + environmental | temporal → `true`, environmental → `true` |
| CVSS 3.1 with env modifiers all `X` but requirement metrics set (CR:M/IR:L/AR:H) | temporal → `true`, environmental → `true` |
| CVSS 2 base-only vector | base → `true`, temporal → `false`, environmental → `false` |
| CVSS 3.0 base-only vector | temporal → `false`, environmental → `false` |

#### `spec/cvss31/cvss31_spec.rb` (9 new tests)

Validates correct `overall_score` routing for CVSS 3.1:

| Scenario | Vector | Expected `overall_score` |
|---|---|---|
| Base-only, Scope: Changed | `CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H` | 9.6 (= `base_score`) |
| Base-only, Scope: Changed | `CVSS:3.1/AV:P/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H` | 7.6 (= `base_score`) |
| Base-only, Scope: Changed | `CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:H` | 9.0 (= `base_score`) |
| Base-only, Scope: Changed | `CVSS:3.1/AV:A/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H` | 8.8 (= `base_score`) |
| Base-only, Scope: Changed | `CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:C/C:H/I:H/A:H` | 9.0 (= `base_score`) |
| Base-only, Scope: Unchanged | `CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H` | 8.8 (= `base_score`) |
| Temporal-only, Scope: Changed | `CVSS:3.1/.../E:H/RL:T/RC:C` | 9.3 (= `temporal_score`) |
| Temporal-only, Scope: Changed | `CVSS:3.1/.../E:P/RL:O/RC:R` | 8.3 (= `temporal_score`) |
| Environmental-only, Scope: Changed | `CVSS:3.1/.../CR:L/IR:M/AR:H/MAV:N/...` | 7.3 (= `environmental_score`) |

#### `spec/cvss3/cvss3_spec.rb` (4 new tests)

Validates the same fix applies to CVSS 3.0:

| Scenario | Vector | Expected `overall_score` |
|---|---|---|
| Base-only, Scope: Changed | `CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H` | 9.6 (= `base_score`) |
| Base-only, Scope: Changed | `CVSS:3.0/AV:P/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H` | 7.6 (= `base_score`) |
| Base-only, Scope: Changed | `CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:H` | 9.0 (= `base_score`) |
| Temporal-only, Scope: Changed | `CVSS:3.0/.../E:H/RL:T/RC:C` | 9.3 (= `temporal_score`) |

All expected scores verified against the [FIRST CVSS 3.1 Calculator](https://www.first.org/cvss/calculator/3.1) and [NVD Calculator](https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator).

**Total: 28 new tests added, full suite passes (81,132 examples, 0 failures).**


## Types of changes

What types of changes does your code introduce to CvssSuite?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] Unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
