### PR TITLE
Support BigDecimal 4.0

### DIFF
--- a/cvss_suite.gemspec
+++ b/cvss_suite.gemspec
@@ -37,7 +37,7 @@ in version 4.0, 3.1, 3.0 and 2.'
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'bigdecimal', '~> 3.1'
+  spec.add_dependency 'bigdecimal', '>= 3.1', '< 5'
 
   spec.add_development_dependency 'bundler', '2.4.22'
   spec.add_development_dependency 'csv', '~> 3.3'


### PR DESCRIPTION
## Proposed changes

BigDecimal 4.0 is now available but cvss-suite dependency version bounds didn't allow it.

The breaking changes in BigDecimal 4.0 however do not appear to affect cvss-suite so we can raise the version bound.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
