### PR TITLE
Add GitHub Action to publish gem to RubyGems on release

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,31 @@
+name: Push gem
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      id-token: write
+
+    # If you configured a GitHub environment on RubyGems, you must use it here.
+    environment: release
+
+    steps:
+      # Set up
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: ruby
+
+      # Release
+      - uses: rubygems/release-gem@v1


### PR DESCRIPTION
## Summary
Adds a GitHub Actions workflow (`.github/workflows/push.yml`) that automatically publishes the gem to RubyGems whenever a version tag (`v*`) is pushed.

## Details
- Triggers on push of tags matching `v*`
- Uses `actions/checkout@v5` and `ruby/setup-ruby@v1` to set up the environment
- Publishes the gem via `rubygems/release-gem@v1`
- Uses `id-token: write` permission for trusted publishing (OIDC) to RubyGems — no API key/secret needed
- Requires a `release` environment to be configured if one is set up on RubyGems for this gem

## How to release going forward
1. Bump the version in the gemspec
2. Tag the release, e.g. `git tag v1.2.3 && git push --tags`
3. The workflow will build and push the gem to RubyGems automatically