### PR TITLE
deps: remove the bigdecimal upper bound

### DIFF
--- a/cvss_suite.gemspec
+++ b/cvss_suite.gemspec
@@ -38,5 +38,5 @@ in version 4.0, 3.1, 3.0 and 2.'
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/}) # rubocop:disable Gemspec/DeprecatedAttributeAssignment -- removed in the gem-packaging PR
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'bigdecimal', '>= 3.1', '< 5'
+  spec.add_dependency 'bigdecimal', '>= 3.1'
 end


### PR DESCRIPTION
Drops the `< 5` ceiling from the `bigdecimal` runtime dependency, leaving `>= 3.1`.

The gem's use of bigdecimal is limited to `.to_d` and basic arithmetic, the stable part of the API. Pinning below the next major blocks consumers on newer Ruby from resolving, without buying real protection: a breaking change to `.to_d` would surface in the test suite, not in the version bound.

The `< 5` guard was added defensively; removing it is deliberate. If you'd rather keep a semver ceiling as policy, I'll restore it. But the runtime surface is small enough that unbounded is the better default for downstream compatibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)