### PR TITLE
feat: add CvssSuite.metrics for static metric introspection

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -51,6 +51,7 @@ Metrics/BlockLength:
     - 'spec/cvss31/cvss31_spec.rb'
     - 'spec/cvss40/cvss40_spec.rb'
     - 'spec/cvss_metric_spec.rb'
+    - 'spec/cvss_suite_spec.rb'
 
 Style/AsciiComments:
   Enabled: false

--- a/lib/cvss_suite.rb
+++ b/lib/cvss_suite.rb
@@ -24,6 +24,27 @@ module CvssSuite
     { string: 'CVSS:4.0/', version: 4.0 }
   ].freeze
 
+  # The metric groups that make up each CVSS version, in vector order. Keyed by
+  # the same version values as CVSS_VECTOR_BEGINNINGS and Cvss#version, so
+  # CvssSuite.metrics(instance.version) works for every version.
+  METRIC_GROUPS = {
+    2 => [['Base', Cvss2Base], ['Temporal', Cvss2Temporal], ['Environmental', Cvss2Environmental]],
+    3.0 => [['Base', Cvss3Base], ['Temporal', Cvss3Temporal], ['Environmental', Cvss3Environmental]],
+    3.1 => [['Base', Cvss31Base], ['Temporal', Cvss31Temporal], ['Environmental', Cvss31Environmental]],
+    4.0 => [['Base', Cvss40Base], ['Threat', Cvss40Threat], ['Environmental', Cvss40Environmental],
+            ['Environmental Security Requirements', Cvss40EnvironmentalSecurity], ['Supplemental', Cvss40Supplemental]]
+  }.freeze
+
+  # Accepted version identifiers mapped to their canonical METRIC_GROUPS key, so
+  # both the canonical value (2, 3.0, ...) and the human-friendly string
+  # ('2', '2.0', '3.1', ...) resolve to the same schema.
+  VERSION_ALIASES = {
+    2 => 2, 2.0 => 2, '2' => 2, '2.0' => 2,
+    3.0 => 3.0, '3.0' => 3.0,
+    3.1 => 3.1, '3.1' => 3.1,
+    4.0 => 4.0, '4.0' => 4.0
+  }.freeze
+
   ##
   # Returns a CVSS class by a +vector+.
   def self.new(vector)
@@ -52,6 +73,28 @@ module CvssSuite
     end
     # rubocop:enable Lint/FloatComparison
   end
+
+  ##
+  # Returns the static schema of metrics and their options for a CVSS +version+
+  # (2, 3.0, 3.1 or 4.0; the equivalent strings are accepted too) without
+  # constructing a vector. Each metric lists its options with the +default+
+  # option flagged, so a caller can build input forms directly. Closes #8.
+  def self.metrics(version)
+    groups = METRIC_GROUPS[VERSION_ALIASES[version]]
+    raise Errors::UnsupportedVersion, "Unsupported CVSS version: #{version.inspect}" if groups.nil?
+
+    groups.map { |label, metric_class| { group: label, metrics: metric_schema(metric_class) } }
+  end
+
+  def self.metric_schema(metric_class)
+    metric_class.new([]).properties.map do |property|
+      options = property.values.map do |value|
+        { name: value[:name], abbreviation: value[:abbreviation], default: value.fetch(:selected, false) }
+      end
+      { name: property.name, abbreviation: property.abbreviation, options: options }
+    end
+  end
+  private_class_method :metric_schema
 
   def self.version
     CVSS_VECTOR_BEGINNINGS.each do |beginning|

--- a/lib/cvss_suite/errors.rb
+++ b/lib/cvss_suite/errors.rb
@@ -23,5 +23,7 @@ module CvssSuite
     class InvalidVector < RuntimeError; end
 
     class InvalidParentClass < ArgumentError; end
+
+    class UnsupportedVersion < ArgumentError; end
   end
 end

--- a/spec/cvss_suite_spec.rb
+++ b/spec/cvss_suite_spec.rb
@@ -33,4 +33,85 @@ describe CvssSuite do
   it 'is invalid' do
     expect(described_class.new('CVSS:3.0/').valid?).to be false
   end
+
+  describe '.metrics' do
+    it 'returns the schema without constructing a vector' do
+      expect(described_class.metrics(3.1)).to be_an(Array)
+    end
+
+    it 'exposes the metric groups for each version in vector order' do
+      expect(described_class.metrics(2).map { |group| group[:group] })
+        .to eq(%w[Base Temporal Environmental])
+      expect(described_class.metrics(3.0).map { |group| group[:group] })
+        .to eq(%w[Base Temporal Environmental])
+      expect(described_class.metrics(3.1).map { |group| group[:group] })
+        .to eq(%w[Base Temporal Environmental])
+      expect(described_class.metrics(4.0).map { |group| group[:group] })
+        .to eq(['Base', 'Threat', 'Environmental', 'Environmental Security Requirements', 'Supplemental'])
+    end
+
+    it 'lists base metric abbreviations in vector order' do
+      base_abbreviations = lambda do |version|
+        described_class.metrics(version).first[:metrics].map { |metric| metric[:abbreviation] }
+      end
+      expect(base_abbreviations.call(2)).to eq(%w[AV AC Au C I A])
+      expect(base_abbreviations.call(3.1)).to eq(%w[AV AC PR UI S C I A])
+      expect(base_abbreviations.call(4.0)).to eq(%w[AV AC AT PR UI VC VI VA SC SI SA])
+    end
+
+    it 'describes each option with a name, abbreviation, and default flag' do
+      attack_vector = described_class.metrics(3.1).first[:metrics].first
+      expect(attack_vector[:name]).to eq('Attack Vector')
+      expect(attack_vector[:abbreviation]).to eq('AV')
+      expect(attack_vector[:options]).to eq(
+        [
+          { name: 'Network', abbreviation: 'N', default: false },
+          { name: 'Adjacent', abbreviation: 'A', default: false },
+          { name: 'Local', abbreviation: 'L', default: false },
+          { name: 'Physical', abbreviation: 'P', default: false }
+        ]
+      )
+    end
+
+    it 'flags the Not Defined option as the default for optional metrics' do
+      exploit_code_maturity = described_class.metrics(3.1).find { |group| group[:group] == 'Temporal' }[:metrics].first
+      defaults = exploit_code_maturity[:options].select { |option| option[:default] }
+      expect(defaults.map { |option| option[:abbreviation] }).to eq(['X'])
+    end
+
+    it 'accepts the canonical version and its string equivalents' do
+      expect(described_class.metrics(2)).to eq(described_class.metrics('2'))
+      expect(described_class.metrics(2)).to eq(described_class.metrics('2.0'))
+      expect(described_class.metrics(3.1)).to eq(described_class.metrics('3.1'))
+      expect(described_class.metrics(4.0)).to eq(described_class.metrics('4.0'))
+    end
+
+    it 'accepts the version reported by a real vector instance, including v2' do
+      {
+        'AV:N/AC:L/Au:N/C:N/I:N/A:C' => 2,
+        'CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H' => 3.0,
+        'CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H' => 3.1,
+        'CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H' => 4.0
+      }.each do |vector, version|
+        expect(described_class.new(vector).version).to eq(version)
+        expect { described_class.metrics(described_class.new(vector).version) }.not_to raise_error
+      end
+    end
+
+    it 'raises an ArgumentError-compatible error for an unsupported version' do
+      expect { described_class.metrics('9.9') }.to raise_error(CvssSuite::Errors::UnsupportedVersion)
+      expect { described_class.metrics(9.9) }.to raise_error(ArgumentError)
+    end
+
+    it 'returns equal data on repeated calls' do
+      expect(described_class.metrics(3.1)).to eq(described_class.metrics(3.1))
+    end
+
+    it 'returns frozen strings a caller cannot corrupt' do
+      schema = described_class.metrics(3.1)
+
+      expect(schema.first[:group]).to be_frozen
+      expect(schema.first[:metrics].first[:options].first[:name]).to be_frozen
+    end
+  end
 end


### PR DESCRIPTION
Adds `CvssSuite.metrics(version)` to expose metric definitions (names, abbreviations, allowed values, defaults) for a CVSS version without a parsed vector.

Today the only way to discover what metrics exist is to parse a full vector string. That's awkward for callers building UI (dropdowns, forms), validation, or docs from the metric set. `CvssSuite.metrics(3.1)` returns the schema directly.

- Accepts any recognized version (2, 3.0, 3.1, 4.0) via the existing alias handling.
- Pure read of the declarative metric definitions; no scoring, no side effects on shared constants.
- Covered by new specs in `spec/cvss_suite_spec.rb`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #8 