### PR TITLE
feat: expose base_score on CVSS 4.0 for NVD/GHSA comparison

### DIFF
--- a/lib/cvss_suite/cvss40/cvss40.rb
+++ b/lib/cvss_suite/cvss40/cvss40.rb
@@ -30,6 +30,14 @@ module CvssSuite
       "#{CvssSuite::CVSS_VECTOR_BEGINNINGS.find { |beginning| beginning[:version] == version }[:string]}#{@vector}"
     end
 
+    ##
+    # Returns the base score of the CVSS vector, ignoring threat and
+    # environmental metrics -- the base score as published by NVD/GHSA.
+    def base_score
+      check_validity
+      @base.score
+    end
+
     private
 
     def init_metrics

--- a/lib/cvss_suite/cvss40/cvss40_base.rb
+++ b/lib/cvss_suite/cvss40/cvss40_base.rb
@@ -20,6 +20,12 @@ module CvssSuite
                 :vulnerable_system_confidentiality, :vulnerable_system_integrity, :vulnerable_system_availability,
                 :subsequent_system_confidentiality, :subsequent_system_integrity, :subsequent_system_availability
 
+    ##
+    # Returns the base score of these metrics, ignoring threat and environmental metrics.
+    def score
+      Cvss40CalcHelper.new(@properties.to_h { |p| [p.abbreviation, p.selected_value[:abbreviation]] }).score
+    end
+
     private
 
     def init_properties

--- a/spec/cvss40/cvss40_spec.rb
+++ b/spec/cvss40/cvss40_spec.rb
@@ -109,4 +109,43 @@ describe CvssSuite::Cvss40 do
       it_behaves_like 'a invalid cvss vector with version', 4.0
     end
   end
+
+  describe '#base_score' do
+    let(:full_impact) { 'CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H' }
+
+    it 'ignores threat metrics (stays the NVD/GHSA-comparable base score)' do
+      expect(CvssSuite.new(full_impact).base_score).to eq(10.0)
+      expect(CvssSuite.new("#{full_impact}/E:U").base_score).to eq(10.0)
+      expect(CvssSuite.new("#{full_impact}/E:U").overall_score).to eq(9.1)
+    end
+
+    it 'ignores environmental metrics' do
+      expect(CvssSuite.new("#{full_impact}/MVI:L/MSA:S").base_score).to eq(10.0)
+      expect(CvssSuite.new("#{full_impact}/MVI:L/MSA:S").overall_score).to eq(9.8)
+    end
+
+    it 'matches the FIRST test-vector base score regardless of threat' do
+      vector = 'CVSS:4.0/AV:A/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N/E:U'
+      expect(CvssSuite.new(vector).base_score).to eq(8.7)
+      expect(CvssSuite.new(vector).overall_score).to eq(6.3)
+    end
+
+    it 'equals overall_score when no threat or environmental metrics are set' do
+      base = 'CVSS:4.0/AV:L/AC:L/AT:N/PR:L/UI:P/VC:N/VI:H/VA:H/SC:N/SI:L/SA:L'
+      cvss = CvssSuite.new(base)
+      expect(cvss.base_score).to eq(cvss.overall_score).and eq(5.2)
+    end
+
+    it 'ignores a full set of threat, environmental and supplemental metrics' do
+      base = 'CVSS:4.0/AV:L/AC:L/AT:N/PR:L/UI:P/VC:N/VI:H/VA:H/SC:N/SI:L/SA:L'
+      modifiers = '/E:P/CR:H/IR:M/AR:H/MAV:A/MAT:P/MPR:N/MVI:H/MVA:N/MSI:H/MSA:N/S:N/V:C/U:Amber'
+      expect(CvssSuite.new(base + modifiers).base_score).to eq(5.2)
+      expect(CvssSuite.new(base + modifiers).overall_score).to eq(4.7)
+    end
+
+    it 'raises for an invalid vector' do
+      invalid = 'CVSS:4.0/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H'
+      expect { CvssSuite.new(invalid).base_score }.to raise_error(CvssSuite::Errors::InvalidVector)
+    end
+  end
 end


### PR DESCRIPTION
Adds `#base_score` to CVSS 4.0, matching the accessor already on the v2/v3 scorers.

CVSS 4.0 folds threat and environmental metrics into a single overall score, so there's no way to get the base-only value. NVD and GHSA publish the base score, so consumers comparing this library against those feeds have nothing to line up for 4.0 vectors. `base_score` closes that gap.

It computes the score from the 11 base metrics with threat/environmental at their spec-defined worst case (E→A, CR/IR/AR→H), which is how the base score is defined. Verified against the FIRST calculator:

- No threat/env present: base equals overall (8.7/8.7, 10.0/10.0).
- Under `E:U`: base holds at 8.7 while overall drops to 6.3.

Covered by new specs in `spec/cvss40/cvss40_spec.rb`, including the invalid-vector path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)