### PR TITLE
build: package only runtime files in the gem

### DIFF
--- a/cvss_suite.gemspec
+++ b/cvss_suite.gemspec
@@ -32,10 +32,12 @@ in version 4.0, 3.1, 3.0 and 2.'
   }
 
   spec.required_ruby_version = '>= 3.3'
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  # Package only what's needed at runtime -- the library code plus its docs and
+  # licence. Dev-only files (CI config, Rakefile, bin/, editor/docs-site config)
+  # are deliberately excluded to keep the published gem minimal.
+  spec.files         = `git ls-files -z -- lib exe LICENSE.md README.md CHANGES.md`.split("\x0")
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/}) # rubocop:disable Gemspec/DeprecatedAttributeAssignment -- removed in the gem-packaging PR
   spec.require_paths = ['lib']
 
   spec.add_dependency 'bigdecimal', '>= 3.1', '< 5'


### PR DESCRIPTION
Narrows `spec.files` to what's needed at runtime: `lib/`, `exe/`, and the three doc files (`LICENSE.md`, `README.md`, `CHANGES.md`), instead of everything `git ls-files` returns minus the test dirs.

The published gem currently ships CI config, the Rakefile, editor and docs-site config, and other dev-only files no installer needs. This trims the package to the library plus its licence and docs.

Also drops the deprecated `spec.test_files` assignment, which the explicit allowlist makes redundant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)