### PR TITLE
docs: cite the CVSS spec formula behind each scoring calculation

### DIFF
--- a/lib/cvss_suite/cvss2/cvss2_base.rb
+++ b/lib/cvss_suite/cvss2/cvss2_base.rb
@@ -21,6 +21,9 @@ module CvssSuite
     # Returns the base score of the CVSS vector. The calculation is based on formula version 2.10 .
     # See CVSS documentation for further information https://www.first.org/cvss/v2/guide#i3.2.1 .
     #
+    # BaseScore = ((0.6 x Impact) + (0.4 x Exploitability) - 1.5) x f(Impact),
+    # where f(Impact) = 0 when Impact is 0, else 1.176.
+    #
     # Takes +Security+ +Requirement+ +Impacts+ for calculating environmental score.
     def score(sr_cr_score = 1, sr_ir_score = 1, sr_ar_score = 1)
       impact = calc_impact(sr_cr_score, sr_ir_score, sr_ar_score)
@@ -75,6 +78,10 @@ module CvssSuite
                                                    { name: 'Complete', abbreviation: 'C', weight: 0.66 }]))
     end
 
+    # CVSS v2, 3.2.1 -- Impact = 10.41 x (1 - (1-C) x (1-I) x (1-A)).
+    # The sr_* args carry the environmental Security Requirements (3.3.1),
+    # defaulting to 1 (= no environmental adjustment) for the plain base score.
+    # https://www.first.org/cvss/v2/guide#i3.2.1
     def calc_impact(sr_cr_score = 1, sr_ir_score = 1, sr_ar_score = 1)
       confidentiality_score = 1 - (@confidentiality_impact.score * sr_cr_score)
       integrity_score = 1 - (@integrity_impact.score * sr_ir_score)
@@ -86,6 +93,8 @@ module CvssSuite
       [10, impact].min
     end
 
+    # CVSS v2, 3.2.1 -- Exploitability = 20 x AccessVector x AccessComplexity x Authentication.
+    # https://www.first.org/cvss/v2/guide#i3.2.1
     def calc_exploitability
       20 * @access_vector.score * @access_complexity.score * @authentication.score
     end

--- a/lib/cvss_suite/cvss3/cvss3_base.rb
+++ b/lib/cvss_suite/cvss3/cvss3_base.rb
@@ -84,6 +84,9 @@ module CvssSuite
                                                    { name: 'High', abbreviation: 'H', weight: 0.56 }]))
     end
 
+    # CVSS v3.0 spec, 8.1 Base Metrics Equations -- Exploitability sub-score:
+    #   8.22 x AttackVector x AttackComplexity x PrivilegesRequired x UserInteraction
+    # https://www.first.org/cvss/v3.0/specification-document
     def calc_exploitability
       privilege_score = Cvss3Helper.privileges_required_score @privileges_required, @scope
 
@@ -91,6 +94,11 @@ module CvssSuite
         privilege_score * @user_interaction.score
     end
 
+    # CVSS v3.0 spec, 8.1 Base Metrics Equations -- Impact sub-score:
+    #   ISCBase = 1 - [(1-C) x (1-I) x (1-A)]
+    #   Scope Changed:   7.52 x (ISCBase - 0.029) - 3.25 x (ISCBase - 0.02)^15
+    #   Scope Unchanged: 6.42 x ISCBase
+    # https://www.first.org/cvss/v3.0/specification-document
     def calc_impact
       isc_base = 1 - ((1 - @confidentiality.score) * (1 - @integrity.score) * (1 - @availability.score))
 

--- a/lib/cvss_suite/cvss3/cvss3_environmental.rb
+++ b/lib/cvss_suite/cvss3/cvss3_environmental.rb
@@ -122,6 +122,10 @@ module CvssSuite
                                                    { name: 'Not Defined', abbreviation: 'X', weight: 1 }]))
     end
 
+    # CVSS v3.0 spec, 8.3 Environmental -- ModifiedImpact from the MISS below:
+    #   Scope Changed:   7.52 x (MISS - 0.029) - 3.25 x (MISS - 0.02)^15
+    #   Scope Unchanged: 6.42 x MISS
+    # https://www.first.org/cvss/v3.0/specification-document
     def modified_impact_sub(isc_modified)
       if scope_changed?
         (7.52 * (isc_modified - 0.029)) - (3.25 * ((isc_modified - 0.02)**15))
@@ -130,6 +134,8 @@ module CvssSuite
       end
     end
 
+    # CVSS v3.0 spec, 8.3 Environmental -- Modified Impact Sub-Score (MISS):
+    #   Minimum(1 - [(1 - MC x CR) x (1 - MI x IR) x (1 - MA x AR)], 0.915)
     def isc_modified
       confidentiality = merged(@modified_confidentiality, @base.confidentiality)
       integrity = merged(@modified_integrity, @base.integrity)
@@ -142,6 +148,8 @@ module CvssSuite
       [0.915, (1 - (confidentiality_score * integrity_score * availability_score))].min
     end
 
+    # CVSS v3.0 spec, 8.3 Environmental -- ModifiedExploitability:
+    #   8.22 x MAV x MAC x MPR x MUI
     def modified_exploitability_sub(privilege_score)
       attack_vector = merged(@modified_attack_vector, @base.attack_vector)
       attack_complexity = merged(@modified_attack_complexity, @base.attack_complexity)
@@ -150,6 +158,9 @@ module CvssSuite
       8.22 * attack_vector.score * attack_complexity.score * privilege_score * user_interaction.score
     end
 
+    # CVSS v3.0 spec, 8.3 Environmental -- ModifiedScore = Roundup(Minimum(
+    #   [1.08 x] (ModifiedImpact + ModifiedExploitability), 10)) x TemporalScore.
+    #   The 1.08 factor applies when the effective (modified) scope is Changed.
     def calculate_score(modified_impact_sub_score, modified_exploitability_sub_score, temporal_score)
       factor = scope_changed? ? 1.08 : 1.0
 

--- a/lib/cvss_suite/cvss31/cvss31_base.rb
+++ b/lib/cvss_suite/cvss31/cvss31_base.rb
@@ -85,6 +85,9 @@ module CvssSuite
                                                    { name: 'High', abbreviation: 'H', weight: 0.56 }]))
     end
 
+    # CVSS v3.1 spec, 7.1 Base Metrics Equations -- Exploitability sub-score:
+    #   8.22 x AttackVector x AttackComplexity x PrivilegesRequired x UserInteraction
+    # https://www.first.org/cvss/v3.1/specification-document
     def calc_exploitability
       privilege_score = Cvss3Helper.privileges_required_score(@privileges_required, @scope)
 
@@ -92,6 +95,15 @@ module CvssSuite
         privilege_score * @user_interaction.score
     end
 
+    # CVSS v3.1 spec, 7.1 Base Metrics Equations -- Impact sub-score:
+    #   ISCBase = 1 - [(1-C) x (1-I) x (1-A)]
+    #   Scope Changed:   7.52 x (ISCBase - 0.029) - 3.25 x (ISCBase - 0.02)^15
+    #   Scope Unchanged: 6.42 x ISCBase
+    # NOTE: v3.1 Base deliberately keeps the exponent 15 from v3.0. Only the
+    # Environmental ModifiedImpact (spec 7.3, see cvss31_environmental.rb) changed
+    # to `x 0.9731` and exponent 13. The two are intentionally different -- do not
+    # "reconcile" them.
+    # https://www.first.org/cvss/v3.1/specification-document
     def calc_impact
       isc_base = 1 - ((1 - @confidentiality.score) * (1 - @integrity.score) * (1 - @availability.score))
 

--- a/lib/cvss_suite/cvss31/cvss31_environmental.rb
+++ b/lib/cvss_suite/cvss31/cvss31_environmental.rb
@@ -122,6 +122,13 @@ module CvssSuite
                                                    { name: 'Not Defined', abbreviation: 'X', weight: 1 }]))
     end
 
+    # CVSS v3.1 spec, 7.3 Environmental -- ModifiedImpact from the MISS below:
+    #   Scope Changed:   7.52 x (MISS - 0.029) - 3.25 x (MISS x 0.9731 - 0.02)^13
+    #   Scope Unchanged: 6.42 x MISS
+    # NOTE: v3.1 changed this Environmental sub-formula to `x 0.9731` and exponent
+    # 13; the v3.1 Base Impact (7.1, see cvss31_base.rb) still uses exponent 15.
+    # The difference is intentional per spec.
+    # https://www.first.org/cvss/v3.1/specification-document
     def modified_impact_sub(isc_modified)
       if scope_changed?
         (7.52 * (isc_modified - 0.029)) - (3.25 * (((isc_modified * 0.9731) - 0.02)**13))
@@ -130,6 +137,8 @@ module CvssSuite
       end
     end
 
+    # CVSS v3.1 spec, 7.3 Environmental -- Modified Impact Sub-Score (MISS):
+    #   Minimum(1 - [(1 - MC x CR) x (1 - MI x IR) x (1 - MA x AR)], 0.915)
     def isc_modified
       confidentiality = merged(@modified_confidentiality, @base.confidentiality)
       integrity = merged(@modified_integrity, @base.integrity)
@@ -142,6 +151,8 @@ module CvssSuite
       [0.915, (1 - (confidentiality_score * integrity_score * availability_score))].min
     end
 
+    # CVSS v3.1 spec, 7.3 Environmental -- ModifiedExploitability:
+    #   8.22 x MAV x MAC x MPR x MUI
     def modified_exploitability_sub(privilege_score)
       attack_vector = merged(@modified_attack_vector, @base.attack_vector)
       attack_complexity = merged(@modified_attack_complexity, @base.attack_complexity)
@@ -150,6 +161,9 @@ module CvssSuite
       8.22 * attack_vector.score * attack_complexity.score * privilege_score * user_interaction.score
     end
 
+    # CVSS v3.1 spec, 7.3 Environmental -- ModifiedScore = Roundup(Minimum(
+    #   [1.08 x] (ModifiedImpact + ModifiedExploitability), 10)) x TemporalScore.
+    #   The 1.08 factor applies when the effective (modified) scope is Changed.
     def calculate_score(modified_impact_sub_score, modified_exploitability_sub_score, temporal_score)
       factor = scope_changed? ? 1.08 : 1.0
 

--- a/lib/cvss_suite/helpers/cvss31_helper.rb
+++ b/lib/cvss_suite/helpers/cvss31_helper.rb
@@ -12,6 +12,10 @@ module CvssSuite
     ##
     # Since CVSS 3 all float values are rounded up, therefore this method is used
     # instead of the mathematically correct method round().
+    # This is the exact Roundup from CVSS v3.1 Appendix A, which works on integer
+    # arithmetic (x100000) to avoid the floating-point edge cases that plain
+    # ceil(1) hits -- the reason v3.1 replaced v3.0's rounding.
+    # https://www.first.org/cvss/v3.1/specification-document
     def self.round_up(float)
       output = (float * 100_000).round
       if (output % 10_000).zero?

--- a/lib/cvss_suite/helpers/cvss3_helper.rb
+++ b/lib/cvss_suite/helpers/cvss3_helper.rb
@@ -19,6 +19,8 @@ module CvssSuite
     ##
     # Since CVSS 3 the Privilege Required score depends on the selected value of the Scope metric.
     # This method takes a +Privilege+ +Required+ and a +Scope+ metric and returns the newly calculated score.
+    # Per the PrivilegesRequired metric table, when Scope is Changed the weights
+    # become PR:Low = 0.68 and PR:High = 0.50 (vs 0.62 / 0.27 when Unchanged).
     def self.privileges_required_score(privileges_required, scope)
       changed = scope.selected_value[:name] == 'Changed'
       privilege_score = privileges_required.score


### PR DESCRIPTION
Adds comment-only citations tying each scoring calculation to the exact CVSS spec formula it implements (v2, v3.0, v3.1 base + environmental).

The scoring code is dense arithmetic with magic constants (`10.41`, `8.22`, `0.9731`, exponents 13 and 15) that mean nothing without the spec open beside you. These comments name the formula each block implements, so the next person changing the math can check it against the source of truth instead of reverse-engineering intent.

They also guard a real footgun: v3.1 Base keeps exponent 15, while v3.1 Environmental applies `x 0.9731` with exponent 13. The two look like they should unify, but reconciling them silently breaks scoring. A NOTE comment flags this at both sites.

No code changes; every added line is a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)