### PR TITLE
feat!: add CvssSuite.parse and make the parsing internals private

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,39 @@ Or install it yourself as:
 
     $ gem install cvss-suite
 
+## Upgrading to 5.x
+
+### Three module methods are now private
+
+`CvssSuite.version`, `CvssSuite.prepare_vector` and `CvssSuite.prepare_cvss2_vector` were public,
+but only because `CvssSuite.new` needed them. They read module-level state that `CvssSuite.new`
+writes, so their return value depended on whichever vector was parsed last, anywhere in the
+process. Calling them directly was never meaningful and is now a `NoMethodError`.
+
+To get the CVSS version of a vector, ask the vector:
+
+```ruby
+# Before (raises NoMethodError as of 5.x)
+CvssSuite.new('CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H')
+CvssSuite.version   # 3.1, but only until anything else parses a vector
+
+# After
+CvssSuite.new('CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H').version   # 3.1
+```
+
+Note that `CvssSuite.version` was never the gem version. That is `CvssSuite::VERSION`, which is
+unchanged. The two names being one letter-case apart is part of why the method is gone.
+
+There is no replacement for `prepare_vector` and `prepare_cvss2_vector`. They strip the
+`CVSS:x.x/` prefix (or the surrounding parentheses of a CVSS 2 vector) before the vector is handed
+to the parser, and that is now an implementation detail of `CvssSuite.new`.
+
+### Nothing else changed
+
+`CvssSuite.new` behaves exactly as it did in 4.x for every input, valid or not, and still never
+raises. `CvssSuite.parse` is new and additive; see [Parsing a vector](#parsing-a-vector) for when to
+reach for which.
+
 ## Version 3.x
 
 If you are still using CvssSuite 3.x please refer to the [specific branch](https://github.com/0llirocks/cvss-suite/tree/3.x) for documentation and changelog.
@@ -122,9 +155,58 @@ valid = cvss.valid?     # false
 cvss.base_score         # will throw CvssSuite::Errors::InvalidVector: Vector is not valid!
 ```
 
+## Parsing a vector
+
+Both entry points return the same object for a valid vector. They differ in what they do with input
+they cannot parse, so pick the failure mode you want.
+
+**`CvssSuite.parse` raises**, at the parse, for every kind of bad input:
+
+```ruby
+CvssSuite.parse('CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H').base_score
+# => 9.8
+CvssSuite.parse('CVSS:3.0/')
+# => raises CvssSuite::Errors::InvalidVector: Vector is not valid!
+```
+
+**`CvssSuite.new` never raises.** It hands back an object whose `valid?` is `false` and defers the
+error to whatever eventually reads a score. What that object is depends on whether the vector's
+prefix was recognised:
+
+| `CvssSuite.new(...)` | returns | `valid?` | `version` | `base_score` |
+| --- | --- | --- | --- | --- |
+| `'CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H'` | `Cvss31` | `true` | `3.1` | `9.8` |
+| `'CVSS:3.0/'` | `Cvss3` | `false` | `3.0` | raises `Errors::InvalidVector` |
+| `'AV:N/AC:L'` | `Cvss2` | `false` | `2` | raises `Errors::InvalidVector` |
+| `'random_string'` | `InvalidCvss` | `false` | raises `Errors::InvalidVector` | raises `Errors::InvalidVector` |
+| `1337` | `InvalidCvss` | `false` | raises `Errors::InvalidVector` | raises `Errors::InvalidVector` |
+
+Note the second and third rows: a vector that carries a recognised prefix but an unusable body still
+comes back as a real version class, and `version` still answers. Only `valid?` and the scores tell
+you it is broken.
+
+**Use `CvssSuite.new`** when an invalid vector is an expected input you intend to branch on:
+
+```ruby
+cvss = CvssSuite.new(untrusted_input)
+return render_error unless cvss.valid?
+```
+
+**Use `CvssSuite.parse`** when an invalid vector is a bug. The object `CvssSuite.new` returns stays
+quiet until something asks it for a number, so a caller who forgets `valid?` sees the exception far
+from the input that caused it, or never, if that read sits behind a conditional.
+
+Neither method accepts a missing argument; `CvssSuite.new` and `CvssSuite.parse` both raise
+`ArgumentError` when called with none.
+
 ## Known Issues
 
 There is a possibility of implementations generating different scores (+/- 0,1) due to small floating-point inaccuracies. This can happen due to differences in floating point arithmetic between different languages and hardware platforms.
+
+On an invalid CVSS 3.x vector whose prefix was recognised, `base_score` raises
+`CvssSuite::Errors::InvalidVector` as documented, but `temporal_score` and `environmental_score`
+raise `TypeError` instead. Check `valid?`, or use `CvssSuite.parse`, rather than relying on the
+error class.
 
 ## Changelog
 

--- a/lib/cvss_suite.rb
+++ b/lib/cvss_suite.rb
@@ -75,6 +75,21 @@ module CvssSuite
   end
 
   ##
+  # Returns a CVSS class by a +vector+, raising CvssSuite::Errors::InvalidVector
+  # if the vector cannot be parsed.
+  #
+  # Prefer this over .new when a bad vector is a bug rather than an expected
+  # input: .new answers with an InvalidCvss sentinel that only reports the
+  # problem once a score is asked for, so a caller who forgets +valid?+ carries a
+  # broken vector until something far from the parse blows up.
+  def self.parse(vector)
+    cvss = new(vector)
+    raise Errors::InvalidVector, 'Vector is not valid!' unless cvss.valid?
+
+    cvss
+  end
+
+  ##
   # Returns the static schema of metrics and their options for a CVSS +version+
   # (2, 3.0, 3.1 or 4.0; the equivalent strings are accepted too) without
   # constructing a vector. Each metric lists its options with the +default+
@@ -135,4 +150,8 @@ module CvssSuite
       vector[start_of_vector..]
     end
   end
+
+  # Parsing internals. They read module state set by .new, so calling them
+  # directly was never meaningful; they were public only because .new needs them.
+  private_class_method :version, :prepare_vector, :prepare_cvss2_vector
 end

--- a/spec/cvss_suite_spec.rb
+++ b/spec/cvss_suite_spec.rb
@@ -114,4 +114,43 @@ describe CvssSuite do
       expect(schema.first[:metrics].first[:options].first[:name]).to be_frozen
     end
   end
+
+  describe '.parse' do
+    {
+      'AV:N/AC:L/Au:N/C:N/I:N/A:C' => CvssSuite::Cvss2,
+      'CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H' => CvssSuite::Cvss3,
+      'CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H' => CvssSuite::Cvss31,
+      'CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H' => CvssSuite::Cvss40
+    }.each do |vector, klass|
+      it "'#{vector}' is expected to return a #{klass}" do
+        expect(described_class.parse(vector)).to be_a(klass)
+      end
+    end
+
+    it 'returns a vector that scores' do
+      expect(described_class.parse('CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H').base_score).to eq(9.8)
+    end
+
+    ['Not a valid vector!', 'CVSS:3.0/', 1337].each do |input|
+      it "raises for #{input.inspect} instead of returning a sentinel" do
+        expect { described_class.parse(input) }
+          .to raise_error(CvssSuite::Errors::InvalidVector, 'Vector is not valid!')
+      end
+    end
+
+    it 'leaves .new lenient so existing callers keep their sentinel' do
+      expect(described_class.new('Not a valid vector!')).to be_a(CvssSuite::InvalidCvss)
+    end
+  end
+
+  describe 'public API surface' do
+    # These were public only because .new needed them; they are parsing internals
+    # that depend on module state and are meaningless to call directly.
+    %i[version prepare_vector prepare_cvss2_vector].each do |internal|
+      it "no longer exposes .#{internal}" do
+        expect(described_class).not_to respond_to(internal)
+        expect { described_class.public_send(internal) }.to raise_error(NoMethodError)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Two breaking changes for the 5.0 that `CHANGES.md` already anticipates. Both are small; the reasoning is in the commit message.

### `CvssSuite.parse`

`CvssSuite.new` answers every bad vector with an object that stays quiet until something reads a score, so a caller who forgets `valid?` meets the exception far from the input that caused it, or never, if that read sits behind a conditional. `CvssSuite.parse` raises `Errors::InvalidVector` at the parse instead.

`.new` is unchanged and keeps its lenient contract for callers that branch on `valid?`. This part is purely additive.

### `CvssSuite.version`, `.prepare_vector`, `.prepare_cvss2_vector` are now private

They were public only because `.new` needed them, and they read module-level state that `.new` writes, so their return value depended on whichever vector was parsed last, anywhere in the process. `.version` was the most confusing of the three: one letter-case away from `CvssSuite::VERSION`, and about the vector rather than the gem.

Migration is `CvssSuite.new(vector).version`, documented in the README.

### Notes

- Documenting this turned up something worth recording: `CvssSuite.new` has two distinct failure shapes. An unrecognized prefix yields `InvalidCvss`, while a recognized prefix with an unusable body yields a real version class that still answers `version`. The README now states this, since the previous wording implied only the first.
- No version bump here. That is yours to cut.
- Touches `lib/cvss_suite.rb` near #68, so whichever merges second will want a trivial conflict resolution.

81,150 examples pass, RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)