### PR TITLE
docs: rewrite the README, and fix the scoring bug that writing it exposed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,220 +1,104 @@
 # CvssSuite for Ruby
 
-[![Gem Version](http://img.shields.io/gem/v/cvss-suite.svg)](https://rubygems.org/gems/cvss-suite)
-[![Ruby Version](https://img.shields.io/badge/Ruby-3.3+-brightgreen.svg)](https://rubygems.org/gems/cvss-suite)
-[![Cvss Support](https://img.shields.io/badge/CVSS-v2-brightgreen.svg)](https://www.first.org/cvss/v2/guide)
-[![Cvss Support](https://img.shields.io/badge/CVSS-v3.0-brightgreen.svg)](https://www.first.org/cvss/v3.0/user-guide)
-[![Cvss Support](https://img.shields.io/badge/CVSS-v3.1-brightgreen.svg)](https://www.first.org/cvss/v3.1/user-guide)
-[![Cvss Support](https://img.shields.io/badge/CVSS-v4.0-brightgreen.svg)](https://www.first.org/cvss/v4.0/user-guide)
-[![RSpec](https://github.com/0llirocks/cvss-suite/workflows/RSpec/badge.svg)](https://github.com/0llirocks/cvss-suite/actions)
+Score a CVSS vector string, and read back every metric you were given.
 
-This Ruby gem helps you to process the vector of the [**Common Vulnerability Scoring System**](https://www.first.org/cvss/specification-document).
-Besides calculating the Base, Temporal and Environmental Score, you are able to extract the selected option.
+CvssSuite turns a vector like `CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N`
+into its scores and its severity, and lets you ask which option each metric selected. It handles
+CVSS 2, 3.0, 3.1 and 4.0 behind one interface, so code that ingests advisories from more than one
+era does not need a branch per specification version.
+
+Most CVSS libraries stop at the number. This one keeps the parsed vector addressable, which is what
+you need to render a vector back to a user, build an input form, or explain a score rather than
+just report it.
 
 > [!IMPORTANT]
 > This project could need some new maintainer(s). I am having less time and motivation to support this gem. Support for v4 was only possible with the help of the community and I am sure I will not implement any v4.x or v5.x support by myself. Since this gem is used in some projects I will not step down without any kind of support. If you are interested in CVSS and ruby, feel free to work on upcoming issues and let me ([@Ollirocks](https://github.com/0llirocks)) know if you are willing to become a maintainer. As of today there are only a very few issues each year but each new version of CVSS results in quite a lot of work. I am fine with staying the owner of this project until someone is willing to take over completely. I will not vanish from GitHub once and or all :smile: The same applies to the ruby gems account, I am willing to push new versions to rubygems.org until someone trustworthy is found to take over.
 
-## Installation
+## Facts
 
-Add this line to your application's Gemfile:
+- **Four specification versions, one API.** CVSS [2](https://www.first.org/cvss/v2/guide),
+  [3.0](https://www.first.org/cvss/v3.0/user-guide), [3.1](https://www.first.org/cvss/v3.1/user-guide)
+  and [4.0](https://www.first.org/cvss/v4.0/user-guide), including 4.0 macro-vector scoring.
+  `CvssSuite.parse` picks the version off the vector string.
+- **Metrics stay readable.** Every metric exposes its name, its permitted options, and which option
+  the vector selected, so you can drive a form or an explanation off a parsed vector.
+- **One runtime dependency.** `bigdecimal`, used to keep the arithmetic off binary floats.
+- **81,150 examples** in the test suite, run against Ruby 3.3, current stable, and head.
+- **Ruby 3.3+**, MIT licensed.
+
+## Example
 
 ```ruby
-gem 'cvss-suite'
+require 'cvss_suite'
+
+cvss = CvssSuite.parse('CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N')
+
+cvss.version                                    # => 4.0
+cvss.overall_score                              # => 9.3
+cvss.severity                                   # => 'Critical'
+cvss.base.attack_vector.name                    # => 'Attack Vector'
+cvss.base.attack_vector.selected_value[:name]   # => 'Network'
 ```
 
-Since the naming of this gem is not following the naming convention you can also add the following line to automatically require the gem:
+CVSS 2 and 3.x additionally break the score down into `base_score`, `temporal_score` and
+`environmental_score`. CVSS 4.0 has a single score, so it exposes `overall_score` (and `base_score`
+for comparison against NVD and GHSA).
+
+## Install
+
+Add the gem to your Gemfile. The gem is named `cvss-suite` but loads as `cvss_suite`, so require it
+explicitly:
 
 ```ruby
 gem 'cvss-suite', require: 'cvss_suite'
 ```
 
-And then execute:
+Then:
 
-    $ bundle
-
-Or install it yourself as:
-
-    $ gem install cvss-suite
-
-## Upgrading to 5.x
-
-### Three module methods are now private
-
-`CvssSuite.version`, `CvssSuite.prepare_vector` and `CvssSuite.prepare_cvss2_vector` were public,
-but only because `CvssSuite.new` needed them. They read module-level state that `CvssSuite.new`
-writes, so their return value depended on whichever vector was parsed last, anywhere in the
-process. Calling them directly was never meaningful and is now a `NoMethodError`.
-
-To get the CVSS version of a vector, ask the vector:
-
-```ruby
-# Before (raises NoMethodError as of 5.x)
-CvssSuite.new('CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H')
-CvssSuite.version   # 3.1, but only until anything else parses a vector
-
-# After
-CvssSuite.new('CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H').version   # 3.1
+```console
+$ bundle install
 ```
 
-Note that `CvssSuite.version` was never the gem version. That is `CvssSuite::VERSION`, which is
-unchanged. The two names being one letter-case apart is part of why the method is gone.
+Or, without Bundler:
 
-There is no replacement for `prepare_vector` and `prepare_cvss2_vector`. They strip the
-`CVSS:x.x/` prefix (or the surrounding parentheses of a CVSS 2 vector) before the vector is handed
-to the parser, and that is now an implementation detail of `CvssSuite.new`.
-
-### Nothing else changed
-
-`CvssSuite.new` behaves exactly as it did in 4.x for every input, valid or not, and still never
-raises. `CvssSuite.parse` is new and additive; see [Parsing a vector](#parsing-a-vector) for when to
-reach for which.
-
-## Version 3.x
-
-If you are still using CvssSuite 3.x please refer to the [specific branch](https://github.com/0llirocks/cvss-suite/tree/3.x) for documentation and changelog.
-
-## Version 2.x
-
-If you are still using CvssSuite 2.x please refer to the [specific branch](https://github.com/0llirocks/cvss-suite/tree/2.x) for documentation and changelog.
-    
-## Version 1.x
-
-If you are still using CvssSuite 1.x please refer to the [specific branch](https://github.com/0llirocks/cvss-suite/tree/1.x) for documentation and changelog.
-
-## Usage
-
-```ruby
-require 'cvss_suite'
-
-cvss4 = CvssSuite.new('CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N')
-
-vector = cvss4.vector       # 'CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N'
-version = cvss4.version     # 4.0
-valid = cvss4.valid?        # true
-severity = cvss4.severity   # 'Critical'
-
-cvss31 = CvssSuite.new('CVSS:3.1/AV:P/AC:H/PR:L/UI:R/S:U/C:L/I:L/A:H/E:H/RL:U/RC:U')
-
-vector = cvss31.vector     # 'CVSS:3.1/AV:P/AC:H/PR:L/UI:R/S:U/C:L/I:L/A:H/E:H/RL:U/RC:U'
-version = cvss31.version   # 3.1
-valid = cvss31.valid?      # true
-severity = cvss31.severity # 'Medium'
-
-cvss3 = CvssSuite.new('CVSS:3.0/AV:L/AC:H/PR:L/UI:R/S:C/C:L/I:L/A:L/CR:L/IR:M/AR:H/MAV:N/MAC:H/MPR:N/MUI:R/MS:U/MC:N/MI:L/MA:H')
-
-vector = cvss3.vector       # 'CVSS:3.0/AV:L/AC:H/PR:L/UI:R/S:C/C:L/I:L/A:L/CR:L/IR:M/AR:H/MAV:N/MAC:H/MPR:N/MUI:R/MS:U/MC:N/MI:L/MA:H'
-version = cvss3.version     # 3.0
-valid = cvss3.valid?        # true
-severity = cvss3.severity   # 'High'
-
-cvss = CvssSuite.new('AV:A/AC:M/Au:S/C:P/I:P/A:P/E:POC/RL:TF/RC:UC/CDP:L/TD:M/CR:M/IR:M/AR:M')
-
-vector = cvss.vector       # 'AV:A/AC:M/Au:S/C:P/I:P/A:P/E:POC/RL:TF/RC:UC/CDP:L/TD:M/CR:M/IR:M/AR:M'
-version = cvss.version     # 2
-valid = cvss.valid?        # true
-severity = cvss.severity   # 'Low'
-
-# Scores
-score = cvss4.overall_score                         # 9.3, cvss4 only has overall score
-base_score = cvss.base_score                        # 4.9
-temporal_score = cvss.temporal_score                # 3.6
-environmental_score = cvss.environmental_score      # 3.2
-overall_score = cvss.overall_score                  # 3.2
-
-# Available options
-access_vector = cvss.base.access_vector.name                # 'Access Vector'
-remediation_level = cvss.temporal.remediation_level.name    # 'Remediation Level'
-
-access_vector.values.each do |value|
-    value[:name]           # 'Local', 'Adjacent Network', 'Network'
-    value[:abbreviation]   # 'L', 'A', 'N'
-    value[:selected]       # false, true, false
-end
-
-# Selected options
-cvss.base.access_vector.selected_value[:name]          # Adjacent Network
-cvss.temporal.remediation_level.selected_value[:name]  # Temporary Fix
-
-# Exceptions
-
-cvss = CvssSuite.new('random_string')  # invalid vector
-valid = cvss.valid?     # false
-version = cvss.version  # will throw CvssSuite::Errors::InvalidVector: Vector is not valid!
-cvss.base_score         # will throw CvssSuite::Errors::InvalidVector: Vector is not valid!
-
-cvss = CvssSuite.new(1337)  # invalid vector
-valid = cvss.valid?     # false
-version = cvss.version  # will throw CvssSuite::Errors::InvalidVector: Vector is not valid!
-cvss.base_score         # will throw CvssSuite::Errors::InvalidVector: Vector is not valid!
-
-CvssSuite.new()         # will throw a ArgumentError
-
-cvss = CvssSuite.new('AV:N/AC:P/C:P/AV:U/RL:OF/RC:C')   # invalid vector, authentication is missing
-version = cvss.version  # 2
-valid = cvss.valid?     # false
-cvss.base_score         # will throw CvssSuite::Errors::InvalidVector: Vector is not valid!
+```console
+$ gem install cvss-suite
 ```
 
-## Parsing a vector
+## Documentation
 
-Both entry points return the same object for a valid vector. They differ in what they do with input
-they cannot parse, so pick the failure mode you want.
+- **[Usage](https://github.com/0llirocks/cvss-suite/blob/master/docs/usage.md)** covers every score, reading and enumerating metrics, and how invalid
+  vectors behave.
+- **[Upgrading to 5.x](https://github.com/0llirocks/cvss-suite/blob/master/docs/upgrading-to-5.md)** lists the breaking changes and the migration for
+  each.
+- **[API reference](https://www.rubydoc.info/gems/cvss-suite)** on RubyDoc.
 
-**`CvssSuite.parse` raises**, at the parse, for every kind of bad input:
+Using an older major? Documentation and changelog live on the
+[3.x](https://github.com/0llirocks/cvss-suite/tree/3.x),
+[2.x](https://github.com/0llirocks/cvss-suite/tree/2.x) and
+[1.x](https://github.com/0llirocks/cvss-suite/tree/1.x) branches.
 
-```ruby
-CvssSuite.parse('CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H').base_score
-# => 9.8
-CvssSuite.parse('CVSS:3.0/')
-# => raises CvssSuite::Errors::InvalidVector: Vector is not valid!
-```
+## Known issues
 
-**`CvssSuite.new` never raises.** It hands back an object whose `valid?` is `false` and defers the
-error to whatever eventually reads a score. What that object is depends on whether the vector's
-prefix was recognised:
+Implementations can produce scores differing by +/- 0.1 because floating-point arithmetic differs
+between languages and hardware platforms.
 
-| `CvssSuite.new(...)` | returns | `valid?` | `version` | `base_score` |
-| --- | --- | --- | --- | --- |
-| `'CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H'` | `Cvss31` | `true` | `3.1` | `9.8` |
-| `'CVSS:3.0/'` | `Cvss3` | `false` | `3.0` | raises `Errors::InvalidVector` |
-| `'AV:N/AC:L'` | `Cvss2` | `false` | `2` | raises `Errors::InvalidVector` |
-| `'random_string'` | `InvalidCvss` | `false` | raises `Errors::InvalidVector` | raises `Errors::InvalidVector` |
-| `1337` | `InvalidCvss` | `false` | raises `Errors::InvalidVector` | raises `Errors::InvalidVector` |
-
-Note the second and third rows: a vector that carries a recognised prefix but an unusable body still
-comes back as a real version class, and `version` still answers. Only `valid?` and the scores tell
-you it is broken.
-
-**Use `CvssSuite.new`** when an invalid vector is an expected input you intend to branch on:
-
-```ruby
-cvss = CvssSuite.new(untrusted_input)
-return render_error unless cvss.valid?
-```
-
-**Use `CvssSuite.parse`** when an invalid vector is a bug. The object `CvssSuite.new` returns stays
-quiet until something asks it for a number, so a caller who forgets `valid?` sees the exception far
-from the input that caused it, or never, if that read sits behind a conditional.
-
-Neither method accepts a missing argument; `CvssSuite.new` and `CvssSuite.parse` both raise
-`ArgumentError` when called with none.
-
-## Known Issues
-
-There is a possibility of implementations generating different scores (+/- 0,1) due to small floating-point inaccuracies. This can happen due to differences in floating point arithmetic between different languages and hardware platforms.
-
-On an invalid CVSS 3.x vector whose prefix was recognised, `base_score` raises
-`CvssSuite::Errors::InvalidVector` as documented, but `temporal_score` and `environmental_score`
-raise `TypeError` instead. Check `valid?`, or use `CvssSuite.parse`, rather than relying on the
-error class.
+Only `version` and `base_score` reliably raise `CvssSuite::Errors::InvalidVector` on an invalid
+vector. `temporal_score`, `environmental_score` and `overall_score` can raise `TypeError` or
+`NoMethodError` instead, depending on the CVSS version and how the vector is malformed. Guard on
+`valid?`, or use `CvssSuite.parse`, rather than rescuing a specific error class.
 
 ## Changelog
 
-[Click here to see all changes.](https://github.com/0llirocks/cvss-suite/blob/master/CHANGES.md)
+Changes through 4.x are in [CHANGES.md](https://github.com/0llirocks/cvss-suite/blob/master/CHANGES.md). From 5.0.0 onwards, see the
+[Releases page](https://github.com/0llirocks/cvss-suite/releases).
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/0llirocks/cvss-suite. This project is intended to be a safe, welcoming space for collaboration.
+Bug reports and pull requests are welcome at
+[github.com/0llirocks/cvss-suite](https://github.com/0llirocks/cvss-suite). This project is intended
+to be a safe, welcoming space for collaboration.
 
 ## References
+
 [CvssSuite for .NET](https://cvsssuite.0lli.rocks)

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ just report it.
 - **Metrics stay readable.** Every metric exposes its name, its permitted options, and which option
   the vector selected, so you can drive a form or an explanation off a parsed vector.
 - **One runtime dependency.** `bigdecimal`, used to keep the arithmetic off binary floats.
-- **81,150 examples** in the test suite, run against Ruby 3.3, current stable, and head.
+- **Over 80,000 examples** in the test suite, run against the oldest supported Ruby, current
+  stable, and head.
 - **Ruby 3.3+**, MIT licensed.
 
 ## Example
@@ -82,11 +83,6 @@ Using an older major? Documentation and changelog live on the
 
 Implementations can produce scores differing by +/- 0.1 because floating-point arithmetic differs
 between languages and hardware platforms.
-
-Only `version` and `base_score` reliably raise `CvssSuite::Errors::InvalidVector` on an invalid
-vector. `temporal_score`, `environmental_score` and `overall_score` can raise `TypeError` or
-`NoMethodError` instead, depending on the CVSS version and how the vector is malformed. Guard on
-`valid?`, or use `CvssSuite.parse`, rather than rescuing a specific error class.
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -1,31 +1,16 @@
 # CvssSuite for Ruby
 
-Score a CVSS vector string, and read back every metric you were given.
+Score a CVSS vector string, and read back every metric in it.
 
-CvssSuite turns a vector like `CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N`
-into its scores and its severity, and lets you ask which option each metric selected. It handles
-CVSS 2, 3.0, 3.1 and 4.0 behind one interface, so code that ingests advisories from more than one
-era does not need a branch per specification version.
+CvssSuite turns a vector string into scores and severity, and lets you ask which option each metric
+selected. It handles four CVSS versions behind one interface, so code that ingests advisories from
+more than one era does not need a branch per specification version.
 
-Most CVSS libraries stop at the number. This one keeps the parsed vector addressable, which is what
-you need to render a vector back to a user, build an input form, or explain a score rather than
-just report it.
+The parsed vector stays addressable, which is what you need to render a vector back to a user, drive
+an input form, or explain a score rather than just report it.
 
 > [!IMPORTANT]
 > This project could need some new maintainer(s). I am having less time and motivation to support this gem. Support for v4 was only possible with the help of the community and I am sure I will not implement any v4.x or v5.x support by myself. Since this gem is used in some projects I will not step down without any kind of support. If you are interested in CVSS and ruby, feel free to work on upcoming issues and let me ([@Ollirocks](https://github.com/0llirocks)) know if you are willing to become a maintainer. As of today there are only a very few issues each year but each new version of CVSS results in quite a lot of work. I am fine with staying the owner of this project until someone is willing to take over completely. I will not vanish from GitHub once and or all :smile: The same applies to the ruby gems account, I am willing to push new versions to rubygems.org until someone trustworthy is found to take over.
-
-## Facts
-
-- **Four specification versions, one API.** CVSS [2](https://www.first.org/cvss/v2/guide),
-  [3.0](https://www.first.org/cvss/v3.0/user-guide), [3.1](https://www.first.org/cvss/v3.1/user-guide)
-  and [4.0](https://www.first.org/cvss/v4.0/user-guide), including 4.0 macro-vector scoring.
-  `CvssSuite.parse` picks the version off the vector string.
-- **Metrics stay readable.** Every metric exposes its name, its permitted options, and which option
-  the vector selected, so you can drive a form or an explanation off a parsed vector.
-- **One runtime dependency.** `bigdecimal`, used to keep the arithmetic off binary floats.
-- **Over 80,000 examples** in the test suite, run against the oldest supported Ruby, current
-  stable, and head.
-- **Ruby 3.3+**, MIT licensed.
 
 ## Example
 
@@ -41,14 +26,28 @@ cvss.base.attack_vector.name                    # => 'Attack Vector'
 cvss.base.attack_vector.selected_value[:name]   # => 'Network'
 ```
 
-CVSS 2 and 3.x additionally break the score down into `base_score`, `temporal_score` and
-`environmental_score`. CVSS 4.0 has a single score, so it exposes `overall_score` (and `base_score`
-for comparison against NVD and GHSA).
+`CvssSuite.new` is the non-raising counterpart, unchanged since 4.x: it returns an object whose
+`valid?` reports the problem instead. CVSS 2 and 3.x also expose `base_score`, `temporal_score` and
+`environmental_score`. See [Usage](https://github.com/0llirocks/cvss-suite/blob/master/docs/usage.md)
+for both.
+
+## What you get
+
+- **Four specification versions, one API.** CVSS [2](https://www.first.org/cvss/v2/guide),
+  [3.0](https://www.first.org/cvss/v3.0/user-guide), [3.1](https://www.first.org/cvss/v3.1/user-guide)
+  and [4.0](https://www.first.org/cvss/v4.0/user-guide), including 4.0 macro-vector scoring.
+  `CvssSuite.parse` picks the version off the vector string.
+- **Metrics stay readable.** Every metric exposes its name, its permitted options, and which option
+  the vector selected.
+- **One runtime dependency.** `bigdecimal`, to keep arithmetic off binary floats.
+- **Over 80,000 examples** in the test suite, run against the oldest supported Ruby, current
+  stable, and head.
+- **Ruby 3.3+**, MIT licensed.
 
 ## Install
 
-Add the gem to your Gemfile. The gem is named `cvss-suite` but loads as `cvss_suite`, so require it
-explicitly:
+Add the gem to your Gemfile. The gem is named `cvss-suite` but loads as `cvss_suite`, so tell
+Bundler which file to load:
 
 ```ruby
 gem 'cvss-suite', require: 'cvss_suite'
@@ -60,7 +59,7 @@ Then:
 $ bundle install
 ```
 
-Or, without Bundler:
+Or without Bundler:
 
 ```console
 $ gem install cvss-suite
@@ -68,10 +67,10 @@ $ gem install cvss-suite
 
 ## Documentation
 
-- **[Usage](https://github.com/0llirocks/cvss-suite/blob/master/docs/usage.md)** covers every score, reading and enumerating metrics, and how invalid
-  vectors behave.
-- **[Upgrading to 5.x](https://github.com/0llirocks/cvss-suite/blob/master/docs/upgrading-to-5.md)** lists the breaking changes and the migration for
-  each.
+- **[Usage](https://github.com/0llirocks/cvss-suite/blob/master/docs/usage.md)** covers every score,
+  reading and enumerating metrics, and how invalid vectors behave.
+- **[Upgrading to 5.x](https://github.com/0llirocks/cvss-suite/blob/master/docs/upgrading-to-5.md)**
+  lists the breaking changes and the migration for each.
 - **[API reference](https://www.rubydoc.info/gems/cvss-suite)** on RubyDoc.
 
 Using an older major? Documentation and changelog live on the
@@ -81,13 +80,14 @@ Using an older major? Documentation and changelog live on the
 
 ## Known issues
 
-Implementations can produce scores differing by +/- 0.1 because floating-point arithmetic differs
-between languages and hardware platforms.
+Other implementations can produce scores differing by +/- 0.1, because floating-point arithmetic
+differs between languages and hardware platforms.
 
 ## Changelog
 
-Changes through 4.x are in [CHANGES.md](https://github.com/0llirocks/cvss-suite/blob/master/CHANGES.md). From 5.0.0 onwards, see the
-[Releases page](https://github.com/0llirocks/cvss-suite/releases).
+Changes through 4.x are in
+[CHANGES.md](https://github.com/0llirocks/cvss-suite/blob/master/CHANGES.md). From 5.0.0 onwards,
+see the [Releases page](https://github.com/0llirocks/cvss-suite/releases).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ for both.
   and [4.0](https://www.first.org/cvss/v4.0/user-guide), including 4.0 macro-vector scoring.
   `CvssSuite.parse` picks the version off the vector string.
 - **Metrics stay readable.** Every metric exposes its name, its permitted options, and which option
-  the vector selected.
+  the vector selected. `CvssSuite.metrics` returns the same schema without a vector, for building
+  input forms.
 - **One runtime dependency.** `bigdecimal`, to keep arithmetic off binary floats.
 - **Over 80,000 examples** in the test suite, run against the oldest supported Ruby, current
   stable, and head.

--- a/cvss_suite.gemspec
+++ b/cvss_suite.gemspec
@@ -35,7 +35,7 @@ in version 4.0, 3.1, 3.0 and 2.'
   # Package only what's needed at runtime -- the library code plus its docs and
   # licence. Dev-only files (CI config, Rakefile, bin/, editor/docs-site config)
   # are deliberately excluded to keep the published gem minimal.
-  spec.files         = `git ls-files -z -- lib exe LICENSE.md README.md CHANGES.md`.split("\x0")
+  spec.files         = `git ls-files -z -- lib exe docs LICENSE.md README.md CHANGES.md`.split("\x0")
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/docs/upgrading-to-5.md
+++ b/docs/upgrading-to-5.md
@@ -1,51 +1,13 @@
 # Upgrading to 5.x
 
+Most callers need no change. `CvssSuite.new` and every score for a valid vector behave as they did
+in 4.x. What follows is the exceptions.
+
 ## Ruby 3.3 is the minimum
 
-5.x requires Ruby 3.3 or newer. 4.x supported older releases.
+5.x requires Ruby 3.3 or newer. 4.1.4 ran on Ruby 2.6 and newer.
 
-## Three module methods are now private
-
-`CvssSuite.version`, `CvssSuite.prepare_vector` and `CvssSuite.prepare_cvss2_vector` were public,
-but only because `CvssSuite.new` needed them. They read module-level state that `CvssSuite.new`
-writes, so their return value depended on whichever vector was parsed last, anywhere in the
-process. Calling them directly was never meaningful, and now raises `NoMethodError`.
-
-To get the CVSS version of a vector, ask the vector:
-
-```ruby
-# Before (raises NoMethodError as of 5.x)
-CvssSuite.new('CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H')
-CvssSuite.version   # 3.1, but only until anything else parses a vector
-
-# After
-CvssSuite.new('CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H').version   # => 3.1
-```
-
-`CvssSuite.version` was never the gem version. That is `CvssSuite::VERSION`, which is unchanged. The
-two names being one letter-case apart is part of why the method is gone.
-
-There is no replacement for `prepare_vector` and `prepare_cvss2_vector`. They strip the `CVSS:x.x/`
-prefix, or the surrounding parentheses of a CVSS 2 vector, before the vector reaches the parser, and
-that is now an implementation detail of `CvssSuite.new`.
-
-## New: `CvssSuite.parse`
-
-`CvssSuite.parse` raises `CvssSuite::Errors::InvalidVector` on input it cannot parse, where
-`CvssSuite.new` returns an object that reports the problem only through `valid?` and the scores.
-This is additive; `CvssSuite.new` is unchanged and is still the right call when an invalid vector is
-an expected input you branch on. See [Parsing a vector](usage.md#parsing-a-vector).
-
-```ruby
-# 4.x, still works
-cvss = CvssSuite.new(untrusted_input)
-return render_error unless cvss.valid?
-
-# 5.x, when a bad vector is a bug rather than an input
-cvss = CvssSuite.parse(vector_from_our_own_database)
-```
-
-## Invalid vectors now fail instead of scoring
+## Invalid vectors no longer score
 
 In 4.x, only `base_score` checked that the vector was valid before computing. `temporal_score` and
 `environmental_score` did not, so a vector that `valid?` had already rejected could still hand back
@@ -59,16 +21,54 @@ cvss.environmental_score  # 4.x: 6.2
                           # 5.x: raises CvssSuite::Errors::InvalidVector
 ```
 
-`overall_score` on the `InvalidCvss` returned for unrecognised input used to raise `NoMethodError`
+`overall_score` on the `InvalidCvss` returned for unrecognized input used to raise `NoMethodError`
 rather than `InvalidVector`. It now raises `InvalidVector` like every other reader.
 
 If you were rescuing `TypeError` or `NoMethodError` around these calls, rescue
-`CvssSuite::Errors::InvalidVector` instead. If you were not checking `valid?` and not rescuing
-anything, calls that previously returned a wrong number now raise, which is the point of the change.
+`CvssSuite::Errors::InvalidVector` instead. If you were checking `valid?` first, nothing changes.
 
-Scores for valid vectors are unchanged, across all four CVSS versions.
+## Three module methods are now private
 
-## Nothing else changed
+`CvssSuite.version`, `CvssSuite.prepare_vector` and `CvssSuite.prepare_cvss2_vector` were public,
+but only because `CvssSuite.new` needed them. They read module-level state that `CvssSuite.new`
+writes, so their return value depended on whichever vector was parsed last, anywhere in the
+process. Calling them directly could not be relied on, and now raises `NoMethodError`.
 
-`CvssSuite.new` still never raises, and still returns the same object for the same input. Metric
-names, permitted options and selected options are unchanged.
+To get the CVSS version of a vector, ask the vector:
+
+```ruby
+# Before (raises NoMethodError as of 5.x)
+CvssSuite.new('CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H')
+CvssSuite.version   # 3.1, but only until anything else parses a vector
+
+# After
+CvssSuite.new('CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H').version   # => 3.1
+```
+
+`CvssSuite.version` was never the gem version; that is `CvssSuite::VERSION`, unchanged.
+
+There is no replacement for `prepare_vector` and `prepare_cvss2_vector`. They strip the `CVSS:x.x/`
+prefix, or the surrounding parentheses of a CVSS 2 vector, before the vector reaches the parser, and
+that is now an implementation detail of `CvssSuite.new`.
+
+## `CvssSuite.parse` is new
+
+`CvssSuite.parse` raises `CvssSuite::Errors::InvalidVector` on input it cannot parse, where
+`CvssSuite.new` returns an object that reports the problem only through `valid?` and the scores.
+This is additive; `CvssSuite.new` is unchanged. See
+[Parsing a vector](usage.md#parsing-a-vector).
+
+```ruby
+# 4.x, still works
+cvss = CvssSuite.new(untrusted_input)
+return render_error unless cvss.valid?
+
+# 5.x, when a bad vector is a bug rather than an input
+cvss = CvssSuite.parse(vector_from_our_own_database)
+```
+
+## What did not change
+
+Scores for valid vectors are unchanged across all four CVSS versions. `CvssSuite.new` still never
+raises, and still returns the same object for the same input. Metric names, permitted options and
+selected options are unchanged.

--- a/docs/upgrading-to-5.md
+++ b/docs/upgrading-to-5.md
@@ -45,7 +45,30 @@ return render_error unless cvss.valid?
 cvss = CvssSuite.parse(vector_from_our_own_database)
 ```
 
+## Invalid vectors now fail instead of scoring
+
+In 4.x, only `base_score` checked that the vector was valid before computing. `temporal_score` and
+`environmental_score` did not, so a vector that `valid?` had already rejected could still hand back
+a plausible-looking number:
+
+```ruby
+cvss = CvssSuite.new('AV:A/AC:H/Au:M/C:C/I:C/A:C/ZZ:Q')   # ZZ is not a CVSS 2 metric
+
+cvss.valid?               # => false, in both 4.x and 5.x
+cvss.environmental_score  # 4.x: 6.2
+                          # 5.x: raises CvssSuite::Errors::InvalidVector
+```
+
+`overall_score` on the `InvalidCvss` returned for unrecognised input used to raise `NoMethodError`
+rather than `InvalidVector`. It now raises `InvalidVector` like every other reader.
+
+If you were rescuing `TypeError` or `NoMethodError` around these calls, rescue
+`CvssSuite::Errors::InvalidVector` instead. If you were not checking `valid?` and not rescuing
+anything, calls that previously returned a wrong number now raise, which is the point of the change.
+
+Scores for valid vectors are unchanged, across all four CVSS versions.
+
 ## Nothing else changed
 
-`CvssSuite.new` behaves exactly as it did in 4.x for every input, valid or not, and still never
-raises. Scores, severities, metric names and selected options are unchanged.
+`CvssSuite.new` still never raises, and still returns the same object for the same input. Metric
+names, permitted options and selected options are unchanged.

--- a/docs/upgrading-to-5.md
+++ b/docs/upgrading-to-5.md
@@ -1,0 +1,51 @@
+# Upgrading to 5.x
+
+## Ruby 3.3 is the minimum
+
+5.x requires Ruby 3.3 or newer. 4.x supported older releases.
+
+## Three module methods are now private
+
+`CvssSuite.version`, `CvssSuite.prepare_vector` and `CvssSuite.prepare_cvss2_vector` were public,
+but only because `CvssSuite.new` needed them. They read module-level state that `CvssSuite.new`
+writes, so their return value depended on whichever vector was parsed last, anywhere in the
+process. Calling them directly was never meaningful, and now raises `NoMethodError`.
+
+To get the CVSS version of a vector, ask the vector:
+
+```ruby
+# Before (raises NoMethodError as of 5.x)
+CvssSuite.new('CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H')
+CvssSuite.version   # 3.1, but only until anything else parses a vector
+
+# After
+CvssSuite.new('CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H').version   # => 3.1
+```
+
+`CvssSuite.version` was never the gem version. That is `CvssSuite::VERSION`, which is unchanged. The
+two names being one letter-case apart is part of why the method is gone.
+
+There is no replacement for `prepare_vector` and `prepare_cvss2_vector`. They strip the `CVSS:x.x/`
+prefix, or the surrounding parentheses of a CVSS 2 vector, before the vector reaches the parser, and
+that is now an implementation detail of `CvssSuite.new`.
+
+## New: `CvssSuite.parse`
+
+`CvssSuite.parse` raises `CvssSuite::Errors::InvalidVector` on input it cannot parse, where
+`CvssSuite.new` returns an object that reports the problem only through `valid?` and the scores.
+This is additive; `CvssSuite.new` is unchanged and is still the right call when an invalid vector is
+an expected input you branch on. See [Parsing a vector](usage.md#parsing-a-vector).
+
+```ruby
+# 4.x, still works
+cvss = CvssSuite.new(untrusted_input)
+return render_error unless cvss.valid?
+
+# 5.x, when a bad vector is a bug rather than an input
+cvss = CvssSuite.parse(vector_from_our_own_database)
+```
+
+## Nothing else changed
+
+`CvssSuite.new` behaves exactly as it did in 4.x for every input, valid or not, and still never
+raises. Scores, severities, metric names and selected options are unchanged.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,11 +1,13 @@
 # Usage
 
+Every score, every metric, and what invalid vectors do.
+
 ## Parsing a vector
 
-Both entry points return the same object for a valid vector. They differ in what they do with input
-they cannot parse, so pick the failure mode you want.
+`CvssSuite.parse` and `CvssSuite.new` return the same object for a valid vector. They differ on
+input they cannot parse; pick the failure mode you want.
 
-**`CvssSuite.parse` raises**, at the parse, for every kind of bad input:
+**`CvssSuite.parse` raises immediately** on any bad input:
 
 ```ruby
 CvssSuite.parse('CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H').base_score
@@ -16,7 +18,7 @@ CvssSuite.parse('CVSS:3.0/')
 
 **`CvssSuite.new` never raises.** It hands back an object whose `valid?` is `false` and defers the
 error to whatever eventually reads a score. What that object is depends on whether the vector's
-prefix was recognised:
+prefix was recognized:
 
 | `CvssSuite.new(...)` | returns | `valid?` | `version` | `base_score` |
 | --- | --- | --- | --- | --- |
@@ -26,9 +28,8 @@ prefix was recognised:
 | `'random_string'` | `InvalidCvss` | `false` | raises `Errors::InvalidVector` | raises `Errors::InvalidVector` |
 | `1337` | `InvalidCvss` | `false` | raises `Errors::InvalidVector` | raises `Errors::InvalidVector` |
 
-Note the second and third rows: a vector carrying a recognised prefix but an unusable body still
-comes back as a real version class, and `version` still answers. Only `valid?` and the scores
-report that it is broken.
+Note rows two and three: a recognized prefix with an unusable body still comes back as a real
+version class.
 
 Use `CvssSuite.new` when an invalid vector is an expected input you intend to branch on:
 
@@ -39,9 +40,9 @@ return render_error unless cvss.valid?
 
 Use `CvssSuite.parse` when an invalid vector is a bug. The object `CvssSuite.new` returns stays
 quiet until something asks it for a number, so a caller who forgets `valid?` meets the exception far
-from the input that caused it, or never, if that read sits behind a conditional.
+from the input that caused it. Or never, if that read sits behind a conditional.
 
-Both raise `ArgumentError` when called with no argument at all.
+Both raise `ArgumentError` when called with no argument.
 
 CVSS 2 vectors are accepted with or without surrounding parentheses. Otherwise the string must begin
 with the vector: anything before the `CVSS:x.x/` prefix, or before a CVSS 2 vector's first metric,
@@ -60,12 +61,14 @@ cvss.environmental_score   # => 3.2
 cvss.overall_score         # => 3.2
 ```
 
-`overall_score` is the most specific score the vector actually provides: the environmental score if
-environmental metrics were given, otherwise the temporal score if temporal metrics were given,
-otherwise the base score.
+`overall_score` is the most specific score the vector provides:
+
+- the environmental score, if environmental metrics were given
+- otherwise the temporal score, if temporal metrics were given
+- otherwise the base score
 
 CVSS 4.0 defines a single score. `overall_score` is that score, and `base_score` is exposed
-alongside it so a 4.0 vector can be compared against the base score NVD and GHSA publish:
+alongside it so a 4.0 vector can be compared against the base score that NVD and GHSA publish:
 
 ```ruby
 cvss = CvssSuite.parse('CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N')
@@ -84,7 +87,7 @@ differ, and so does the score each one reads:
 | CVSS 3.0, 3.1, 4.0 | None, Low, Medium, High, Critical | `overall_score` |
 | CVSS 2 | Low, Medium, High | `base_score` |
 
-CVSS 2 predates the Critical band and rates on the base score, so a v2 vector can report a severity
+CVSS 2 predates the Critical band and rates on the base score, so a CVSS 2 vector can report a severity
 that looks inconsistent with its own `overall_score`:
 
 ```ruby
@@ -98,7 +101,7 @@ cvss.severity        # => 'Medium', rated on the 4.9 base score
 ## Reading metrics
 
 A parsed vector exposes its metric groups. Every version has `base`. CVSS 2 and 3.x add `temporal`
-and `environmental`. CVSS 4.0 instead has `threat`, `environmental`, `environmental_security` and
+and `environmental`. CVSS 4.0 has `threat`, `environmental`, `environmental_security` and
 `supplemental`. Each metric answers its human-readable name, all permitted options, and the option
 this vector selected.
 
@@ -119,13 +122,11 @@ cvss.temporal.remediation_level.name                   # => 'Remediation Level'
 cvss.temporal.remediation_level.selected_value[:name]  # => 'Temporary Fix'
 ```
 
-On CVSS 2 and 3.x, `weight` is the numeric coefficient the specification assigns to that option. It
-is what the score is computed from, and is included for callers that want to show their working.
-CVSS 4.0 options carry no `weight`, because 4.0 scores through a macro-vector lookup rather than
-per-option coefficients.
+On CVSS 2 and 3.x, `weight` is the numeric coefficient the specification assigns to that option. The
+score is computed from it; it is exposed so you can show your working. CVSS 4.0 options carry no
+`weight`, because 4.0 scores through a macro-vector lookup rather than per-option coefficients.
 
-The original vector string is available too, which is what you want when rendering a parsed vector
-back to a user:
+The original vector string is available too:
 
 ```ruby
 CvssSuite.parse('CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N').vector
@@ -155,7 +156,7 @@ cvss.version      # => raises CvssSuite::Errors::InvalidVector: Vector is not va
 cvss.base_score   # => raises CvssSuite::Errors::InvalidVector: Vector is not valid!
 ```
 
-A vector whose prefix was recognised but whose body is unusable still answers `version`, and only
+A vector whose prefix was recognized but whose body is unusable still answers `version`, and only
 reports the problem through `valid?` and the scores:
 
 ```ruby
@@ -166,15 +167,15 @@ cvss.valid?       # => false
 cvss.base_score   # => raises CvssSuite::Errors::InvalidVector: Vector is not valid!
 ```
 
-Every error class lives under `CvssSuite::Errors`. `InvalidVector` descends from `RuntimeError`, so
-a bare `rescue => e` catches it.
-
-Every score reader a version defines behaves the same way. On CVSS 2 and 3.x that is `base_score`,
-`temporal_score`, `environmental_score`, `overall_score` and `severity`. CVSS 4.0 folds threat and
-environmental metrics into its single score, so it defines only `base_score`, `overall_score` and
-`severity`; calling `temporal_score` or `environmental_score` on a 4.0 vector raises `NoMethodError`
-whether or not the vector is valid.
+Every score reader behaves the same way. On CVSS 2 and 3.x that is `base_score`, `temporal_score`,
+`environmental_score`, `overall_score` and `severity`. CVSS 4.0 folds threat and environmental
+metrics into its single score, so it defines only `base_score`, `overall_score` and `severity`;
+calling `temporal_score` or `environmental_score` on a 4.0 vector raises `NoMethodError` whether or
+not the vector is valid.
 
 The metric groups themselves are not guarded. `cvss.base`, `cvss.temporal` and `cvss.environmental`
 hand back live objects on an invalid vector, and their `score` will compute from it. Read scores
 through the methods above rather than through the metric groups.
+
+Every error class lives under `CvssSuite::Errors`. `InvalidVector` descends from `RuntimeError`, so
+a bare `rescue => e` catches it.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -144,6 +144,40 @@ cvss.base.properties.map(&:abbreviation)
 # => ['AV', 'AC', 'Au', 'C', 'I', 'A']
 ```
 
+## Metrics without a vector
+
+`CvssSuite.metrics` returns the schema for a CVSS version without parsing anything, which is what
+you want when building an input form or validating against the specification rather than against a
+particular vector:
+
+```ruby
+schema = CvssSuite.metrics(3.1)
+
+schema.map { |group| group[:group] }
+# => ['Base', 'Temporal', 'Environmental']
+
+schema.first[:metrics].first
+# => { name: 'Attack Vector',
+#      abbreviation: 'AV',
+#      options: [{ name: 'Network',  abbreviation: 'N', default: false },
+#                { name: 'Adjacent', abbreviation: 'A', default: false },
+#                { name: 'Local',    abbreviation: 'L', default: false },
+#                { name: 'Physical', abbreviation: 'P', default: false }] }
+```
+
+Optional metrics flag their Not Defined option as the default, so a form can preselect it:
+
+```ruby
+temporal = CvssSuite.metrics(3.1).find { |group| group[:group] == 'Temporal' }
+temporal[:metrics].first[:name]                                          # => 'Exploit Code Maturity'
+temporal[:metrics].first[:options].select { |o| o[:default] }.map { |o| o[:abbreviation] }
+# => ['X']
+```
+
+It accepts `2`, `3.0`, `3.1` and `4.0`, the string equivalents of each, and the value a parsed
+vector reports from `version`. Anything else raises `CvssSuite::Errors::UnsupportedVersion`, which
+descends from `ArgumentError`.
+
 ## Exceptions
 
 Reading a score or a version off an invalid vector raises `CvssSuite::Errors::InvalidVector`:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -145,7 +145,7 @@ cvss.base.properties.map(&:abbreviation)
 
 ## Exceptions
 
-Reading `version` or `base_score` off an invalid vector raises `CvssSuite::Errors::InvalidVector`:
+Reading a score or a version off an invalid vector raises `CvssSuite::Errors::InvalidVector`:
 
 ```ruby
 cvss = CvssSuite.new('random_string')
@@ -169,14 +169,12 @@ cvss.base_score   # => raises CvssSuite::Errors::InvalidVector: Vector is not va
 Every error class lives under `CvssSuite::Errors`. `InvalidVector` descends from `RuntimeError`, so
 a bare `rescue => e` catches it.
 
-The other readers are less disciplined. `temporal_score`, `environmental_score` and `overall_score`
-on an invalid vector can raise `TypeError` or `NoMethodError` instead, depending on the version and
-on how the vector is malformed:
+Every score reader a version defines behaves the same way. On CVSS 2 and 3.x that is `base_score`,
+`temporal_score`, `environmental_score`, `overall_score` and `severity`. CVSS 4.0 folds threat and
+environmental metrics into its single score, so it defines only `base_score`, `overall_score` and
+`severity`; calling `temporal_score` or `environmental_score` on a 4.0 vector raises `NoMethodError`
+whether or not the vector is valid.
 
-```ruby
-CvssSuite.new('CVSS:3.1/AV:N').temporal_score                    # => raises TypeError
-CvssSuite.new('AV:N/AC:P/C:P/AV:U/RL:OF/RC:C').environmental_score  # => raises NoMethodError
-CvssSuite.new('random_string').overall_score                     # => raises NoMethodError
-```
-
-Guard on `valid?`, or use `CvssSuite.parse`, rather than rescuing a specific error class.
+The metric groups themselves are not guarded. `cvss.base`, `cvss.temporal` and `cvss.environmental`
+hand back live objects on an invalid vector, and their `score` will compute from it. Read scores
+through the methods above rather than through the metric groups.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,182 @@
+# Usage
+
+## Parsing a vector
+
+Both entry points return the same object for a valid vector. They differ in what they do with input
+they cannot parse, so pick the failure mode you want.
+
+**`CvssSuite.parse` raises**, at the parse, for every kind of bad input:
+
+```ruby
+CvssSuite.parse('CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H').base_score
+# => 9.8
+CvssSuite.parse('CVSS:3.0/')
+# => raises CvssSuite::Errors::InvalidVector: Vector is not valid!
+```
+
+**`CvssSuite.new` never raises.** It hands back an object whose `valid?` is `false` and defers the
+error to whatever eventually reads a score. What that object is depends on whether the vector's
+prefix was recognised:
+
+| `CvssSuite.new(...)` | returns | `valid?` | `version` | `base_score` |
+| --- | --- | --- | --- | --- |
+| `'CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H'` | `Cvss31` | `true` | `3.1` | `9.8` |
+| `'CVSS:3.0/'` | `Cvss3` | `false` | `3.0` | raises `Errors::InvalidVector` |
+| `'AV:N/AC:L'` | `Cvss2` | `false` | `2` | raises `Errors::InvalidVector` |
+| `'random_string'` | `InvalidCvss` | `false` | raises `Errors::InvalidVector` | raises `Errors::InvalidVector` |
+| `1337` | `InvalidCvss` | `false` | raises `Errors::InvalidVector` | raises `Errors::InvalidVector` |
+
+Note the second and third rows: a vector carrying a recognised prefix but an unusable body still
+comes back as a real version class, and `version` still answers. Only `valid?` and the scores
+report that it is broken.
+
+Use `CvssSuite.new` when an invalid vector is an expected input you intend to branch on:
+
+```ruby
+cvss = CvssSuite.new(untrusted_input)
+return render_error unless cvss.valid?
+```
+
+Use `CvssSuite.parse` when an invalid vector is a bug. The object `CvssSuite.new` returns stays
+quiet until something asks it for a number, so a caller who forgets `valid?` meets the exception far
+from the input that caused it, or never, if that read sits behind a conditional.
+
+Both raise `ArgumentError` when called with no argument at all.
+
+CVSS 2 vectors are accepted with or without surrounding parentheses. Otherwise the string must begin
+with the vector: anything before the `CVSS:x.x/` prefix, or before a CVSS 2 vector's first metric,
+makes it unparseable.
+
+## Scores
+
+CVSS 2, 3.0 and 3.1 expose the three sub-scores plus an overall score:
+
+```ruby
+cvss = CvssSuite.parse('AV:A/AC:M/Au:S/C:P/I:P/A:P/E:POC/RL:TF/RC:UC/CDP:L/TD:M/CR:M/IR:M/AR:M')
+
+cvss.base_score            # => 4.9
+cvss.temporal_score        # => 3.6
+cvss.environmental_score   # => 3.2
+cvss.overall_score         # => 3.2
+```
+
+`overall_score` is the most specific score the vector actually provides: the environmental score if
+environmental metrics were given, otherwise the temporal score if temporal metrics were given,
+otherwise the base score.
+
+CVSS 4.0 defines a single score. `overall_score` is that score, and `base_score` is exposed
+alongside it so a 4.0 vector can be compared against the base score NVD and GHSA publish:
+
+```ruby
+cvss = CvssSuite.parse('CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N')
+
+cvss.overall_score   # => 9.3
+cvss.base_score      # => 9.3
+```
+
+## Severity
+
+`severity` maps a score onto the qualitative rating from the specification. The two rating scales
+differ, and so does the score each one reads:
+
+| | scale | reads |
+| --- | --- | --- |
+| CVSS 3.0, 3.1, 4.0 | None, Low, Medium, High, Critical | `overall_score` |
+| CVSS 2 | Low, Medium, High | `base_score` |
+
+CVSS 2 predates the Critical band and rates on the base score, so a v2 vector can report a severity
+that looks inconsistent with its own `overall_score`:
+
+```ruby
+cvss = CvssSuite.parse('AV:A/AC:M/Au:S/C:P/I:P/A:P/E:POC/RL:TF/RC:UC/CDP:L/TD:M/CR:M/IR:M/AR:M')
+
+cvss.base_score      # => 4.9
+cvss.overall_score   # => 3.2
+cvss.severity        # => 'Medium', rated on the 4.9 base score
+```
+
+## Reading metrics
+
+A parsed vector exposes its metric groups. Every version has `base`. CVSS 2 and 3.x add `temporal`
+and `environmental`. CVSS 4.0 instead has `threat`, `environmental`, `environmental_security` and
+`supplemental`. Each metric answers its human-readable name, all permitted options, and the option
+this vector selected.
+
+```ruby
+cvss = CvssSuite.parse('AV:A/AC:M/Au:S/C:P/I:P/A:P/E:POC/RL:TF/RC:UC/CDP:L/TD:M/CR:M/IR:M/AR:M')
+
+access_vector = cvss.base.access_vector
+
+access_vector.name                     # => 'Access Vector'
+access_vector.selected_value[:name]    # => 'Adjacent Network'
+
+access_vector.values
+# => [{ name: 'Network',          abbreviation: 'N', weight: 1.0,   selected: false },
+#     { name: 'Adjacent Network', abbreviation: 'A', weight: 0.646, selected: true  },
+#     { name: 'Local',            abbreviation: 'L', weight: 0.395, selected: false }]
+
+cvss.temporal.remediation_level.name                   # => 'Remediation Level'
+cvss.temporal.remediation_level.selected_value[:name]  # => 'Temporary Fix'
+```
+
+On CVSS 2 and 3.x, `weight` is the numeric coefficient the specification assigns to that option. It
+is what the score is computed from, and is included for callers that want to show their working.
+CVSS 4.0 options carry no `weight`, because 4.0 scores through a macro-vector lookup rather than
+per-option coefficients.
+
+The original vector string is available too, which is what you want when rendering a parsed vector
+back to a user:
+
+```ruby
+CvssSuite.parse('CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N').vector
+# => 'CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N'
+```
+
+One asymmetry: a CVSS 2 vector given in parentheses comes back without them.
+`CvssSuite.parse('(AV:N/AC:L/Au:N/C:N/I:N/A:C)').vector` returns
+`'AV:N/AC:L/Au:N/C:N/I:N/A:C'`.
+
+To enumerate every metric in a group rather than naming one, use `properties`:
+
+```ruby
+cvss.base.properties.map(&:abbreviation)
+# => ['AV', 'AC', 'Au', 'C', 'I', 'A']
+```
+
+## Exceptions
+
+Reading `version` or `base_score` off an invalid vector raises `CvssSuite::Errors::InvalidVector`:
+
+```ruby
+cvss = CvssSuite.new('random_string')
+
+cvss.valid?       # => false
+cvss.version      # => raises CvssSuite::Errors::InvalidVector: Vector is not valid!
+cvss.base_score   # => raises CvssSuite::Errors::InvalidVector: Vector is not valid!
+```
+
+A vector whose prefix was recognised but whose body is unusable still answers `version`, and only
+reports the problem through `valid?` and the scores:
+
+```ruby
+cvss = CvssSuite.new('AV:N/AC:P/C:P/AV:U/RL:OF/RC:C')   # authentication is missing
+
+cvss.version      # => 2
+cvss.valid?       # => false
+cvss.base_score   # => raises CvssSuite::Errors::InvalidVector: Vector is not valid!
+```
+
+Every error class lives under `CvssSuite::Errors`. `InvalidVector` descends from `RuntimeError`, so
+a bare `rescue => e` catches it.
+
+The other readers are less disciplined. `temporal_score`, `environmental_score` and `overall_score`
+on an invalid vector can raise `TypeError` or `NoMethodError` instead, depending on the version and
+on how the vector is malformed:
+
+```ruby
+CvssSuite.new('CVSS:3.1/AV:N').temporal_score                    # => raises TypeError
+CvssSuite.new('AV:N/AC:P/C:P/AV:U/RL:OF/RC:C').environmental_score  # => raises NoMethodError
+CvssSuite.new('random_string').overall_score                     # => raises NoMethodError
+```
+
+Guard on `valid?`, or use `CvssSuite.parse`, rather than rescuing a specific error class.

--- a/lib/cvss_suite/cvss2/cvss2.rb
+++ b/lib/cvss_suite/cvss2/cvss2.rb
@@ -57,6 +57,7 @@ module CvssSuite
     ##
     # Returns the Environmental Score of the CVSS vector.
     def environmental_score
+      check_validity
       return temporal_score unless @environmental.valid?
 
       (@environmental.score @base, @temporal.score).round(1)

--- a/lib/cvss_suite/cvss3/cvss3.rb
+++ b/lib/cvss_suite/cvss3/cvss3.rb
@@ -30,12 +30,14 @@ module CvssSuite
     ##
     # Returns the Temporal Score of the CVSS vector.
     def temporal_score
+      check_validity
       Cvss3Helper.round_up(Cvss3Helper.round_up(@base.score) * @temporal.score)
     end
 
     ##
     # Returns the Environmental Score of the CVSS vector.
     def environmental_score
+      check_validity
       return temporal_score unless @environmental.valid?
 
       Cvss3Helper.round_up(@environmental.score(@base, @temporal))

--- a/lib/cvss_suite/cvss31/cvss31.rb
+++ b/lib/cvss_suite/cvss31/cvss31.rb
@@ -34,6 +34,7 @@ module CvssSuite
     # Returns the Temporal Score of the CVSS vector.
 
     def temporal_score
+      check_validity
       Cvss31Helper.round_up(Cvss31Helper.round_up(@base.score) * @temporal.score)
     end
 
@@ -41,6 +42,7 @@ module CvssSuite
     # Returns the Environmental Score of the CVSS vector.
 
     def environmental_score
+      check_validity
       return temporal_score unless @environmental.valid?
 
       Cvss31Helper.round_up(@environmental.score(@base, @temporal))

--- a/lib/cvss_suite/invalid_cvss.rb
+++ b/lib/cvss_suite/invalid_cvss.rb
@@ -44,5 +44,11 @@ module CvssSuite
     def environmental_score
       check_validity
     end
+
+    ##
+    # Since this is an invalid CVSS vector, it always throws an exception.
+    def overall_score
+      check_validity
+    end
   end
 end

--- a/spec/cvss_suite_spec.rb
+++ b/spec/cvss_suite_spec.rb
@@ -143,6 +143,42 @@ describe CvssSuite do
     end
   end
 
+  describe 'an invalid vector' do
+    # Every score reader should report the same problem the same way. base_score
+    # guarded from the start; temporal_score and environmental_score reached the
+    # arithmetic first and either died there or, worse, returned a score for a
+    # vector valid? had already rejected.
+    all_readers = %i[base_score temporal_score environmental_score overall_score severity]
+    # CVSS 4.0 folds threat and environmental metrics into the one score, so it
+    # defines no temporal_score or environmental_score to guard.
+    cvss40_readers = %i[base_score overall_score severity]
+
+    [
+      ['no recognised prefix', 'random_string', all_readers],
+      ['not a string', 1337, all_readers],
+      ['CVSS 3.1, prefix only', 'CVSS:3.1/AV:N', all_readers],
+      ['CVSS 3.0, prefix only', 'CVSS:3.0/', all_readers],
+      ['CVSS 2, missing authentication', 'AV:N/AC:P/C:P/AV:U/RL:OF/RC:C', all_readers],
+      ['CVSS 2, unknown metric', 'AV:A/AC:H/Au:M/C:C/I:C/A:C/ZZ:Q', all_readers],
+      ['CVSS 4.0, prefix only', 'CVSS:4.0/AV:N', cvss40_readers]
+    ].each do |label, vector, readers|
+      readers.each do |reader|
+        it "raises InvalidVector from ##{reader} (#{label})" do
+          expect { described_class.new(vector).public_send(reader) }
+            .to raise_error(CvssSuite::Errors::InvalidVector, 'Vector is not valid!')
+        end
+      end
+    end
+
+    it 'does not expose temporal or environmental scores on CVSS 4.0 at all' do
+      cvss = described_class.new('CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H')
+
+      expect(cvss).to be_valid
+      expect(cvss).not_to respond_to(:temporal_score)
+      expect(cvss).not_to respond_to(:environmental_score)
+    end
+  end
+
   describe 'public API surface' do
     # These were public only because .new needed them; they are parsing internals
     # that depend on module state and are meaningless to call directly.


### PR DESCRIPTION
### The bug is the important part

Documenting how invalid vectors behave meant checking rather than assuming, and the assumption was wrong. `base_score` checked validity before computing; `temporal_score` and `environmental_score` did not. So a vector `valid?` had already rejected could still hand back a plausible number:

```ruby
cvss = CvssSuite.new('AV:A/AC:H/Au:M/C:C/I:C/A:C/ZZ:Q')   # ZZ is not a CVSS 2 metric
cvss.valid?               # => false
cvss.environmental_score  # => 6.2
```

Across ~18,800 mutated vectors, **22,373 individual reads returned a number for a vector that `valid?` rejects**. Where the arithmetic happened to hit a nil instead, callers got `TypeError` or `NoMethodError` raised from inside the gem; that is the same defect wearing a louder failure. `InvalidCvss` had the matching gap from the other end, overriding every score reader except `overall_score`.

Guarding `temporal_score`/`environmental_score` in the three affected version classes, and defining `InvalidCvss#overall_score`, makes every reader report an invalid vector the same way.

**Scores for valid vectors are unchanged.** Verified by differential test: all 14,214 vectors in `spec/cvss_scores.csv` across all four CVSS versions produce byte-identical output before and after.

This is breaking for anyone rescuing the old error classes, or relying on a number the vector never justified, so it wants the same major as #72.

### The README

Rewritten against [Evil Martians' good-readme skill](https://github.com/evilmartians/agent-skills/blob/HEAD/skills/good-readme/SKILL.md): lead with what the gem does before how to install it, state facts rather than showing badges, and keep the landing page skimmable. The reference material moved into `docs/usage.md` and `docs/upgrading-to-5.md`. The gemspec now packages `docs/` so those ship inside the gem rather than only existing here.

Three claims in the old README were wrong, which is the argument for generating docs from executed output:

- `severity` for the CVSS 2 example was documented as `'Low'`. It is `'Medium'`; `Cvss2#severity` rates the **base** score on v2's three-band scale, not the overall score. That override was undocumented.
- The access vector options were listed in the reverse of their actual order (`N, A, L`, not `L, A, N`).
- The "Available options" example did not run. It assigned `.name` and then called `.values` on the resulting String.

Every sample in the README and both docs is now executed output.

### Two things for you to veto

1. **The badges are gone**, replaced by a text "What you get" section. That is what the skill above calls for, but build status and gem version are your signal to your own users, and it is not a contributor's call to make silently. Say the word and I will restore them.
2. **The `docs/` links are absolute `blob/master` URLs** so they resolve from RubyGems and RubyDoc, where relative links break. They 404 until this merges.

Separately: I would like to talk you out of retiring `CHANGES.md` at 5.0.0, but that is your decision and does not belong in a code PR, so I have left it out of this branch and will raise it as an issue.

81,184 examples pass, RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
